### PR TITLE
Added small sample python code for computing the spectrum of a signal

### DIFF
--- a/python/compute_spectrum.py
+++ b/python/compute_spectrum.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+def compute_spectrum(X, fs):
+    """
+    Computes the fourier of multiple equidistantly samples signals at a time.
+    
+    Parameters
+    ----------
+    X : numpy.ndarray
+        Array of signals where ``X[:,k]`` is the k-th signal.
+    fs : float
+        Sampling frequency.
+    
+    Returns
+    ----------
+    f : numpy.ndarray
+        Freqeuency array.
+    P : numpy.ndarray
+        Power spectrum of the signals.
+    """
+    assert isinstance(X, np.ndarray)
+    assert isinstance(fs, float) and fs > 0.
+    assert X.ndim <= 2
+    
+    from scipy.fftpack import fft, fftfreq
+    from scipy.signal import blackman
+    n = X.shape[0]
+    f = fftfreq(n, d=1. / fs)
+    w = blackman(n)
+    spec = fft(( (X - X.mean(axis=0) ).T * w ).T, axis=0)
+
+    return np.abs(spec[:n//2]), f[:n//2]


### PR DESCRIPTION
This small example shall compute the spectrum of an equidistantly sampled signal. Another method which might as well do the job is Welch's method i.e. [``scipy.signal.welch``](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.welch.html?highlight=welch#scipy.signal.welch).