### PR TITLE
Fix implicit declaration warning

### DIFF
--- a/include/rotatingMHD/assembly_data.h
+++ b/include/rotatingMHD/assembly_data.h
@@ -15,7 +15,6 @@ using namespace dealii;
 namespace AssemblyData
 {
 
-template <int dim>  
 struct CopyBase
 {
   CopyBase(const unsigned int dofs_per_cell);
@@ -33,7 +32,7 @@ struct ScratchBase
   ScratchBase(const Quadrature<dim>     &quadrature_formula,
               const FiniteElement<dim>  &fe);
 
-  ScratchBase(const ScratchBase &data);
+  ScratchBase(const ScratchBase<dim>    &data);
 
   const unsigned int  n_q_points;
 
@@ -46,8 +45,7 @@ namespace Generic
 namespace Matrix
 {
 
-template <int dim>  
-struct Copy : CopyBase<dim>
+struct Copy : CopyBase
 {
   Copy(const unsigned int dofs_per_cell);
 
@@ -56,8 +54,7 @@ struct Copy : CopyBase<dim>
   FullMatrix<double>  local_matrix;
 };
 
-template <int dim>  
-struct MassStiffnessCopy : CopyBase<dim>
+struct MassStiffnessCopy : CopyBase
 {
   MassStiffnessCopy(const unsigned int dofs_per_cell);
 
@@ -76,7 +73,7 @@ struct Scratch : ScratchBase<dim>
           const FiniteElement<dim>  &fe,
           const UpdateFlags         update_flags);
 
-  Scratch(const Scratch &data);
+  Scratch(const Scratch<dim>        &data);
 
   FEValues<dim> fe_values;
 };
@@ -86,8 +83,7 @@ struct Scratch : ScratchBase<dim>
 namespace RightHandSide
 {
 
-template <int dim>  
-struct Copy : CopyBase<dim>
+struct Copy : CopyBase
 {
   Copy(const unsigned int dofs_per_cell);
 
@@ -106,7 +102,7 @@ struct Scratch : ScratchBase<dim>
           const FiniteElement<dim>  &fe,
           const UpdateFlags         update_flags);
 
-  Scratch(const Scratch &data);
+  Scratch(const Scratch<dim>        &data);
 
   FEValues<dim> fe_values;
 };
@@ -120,8 +116,8 @@ namespace NavierStokesProjection
 
 namespace VelocityConstantMatrices
 {
-template<int dim>
-using Copy = Generic::Matrix::MassStiffnessCopy<dim>;
+
+using Copy = Generic::Matrix::MassStiffnessCopy;
 
 template <int dim>  
 struct Scratch : Generic::Matrix::Scratch<dim>
@@ -131,7 +127,7 @@ struct Scratch : Generic::Matrix::Scratch<dim>
           const FiniteElement<dim>  &fe,
           const UpdateFlags         update_flags);
   
-  Scratch(const Scratch &data);
+  Scratch(const Scratch<dim>    &data);
 
   std::vector<Tensor<1, dim>> phi;
   
@@ -143,8 +139,7 @@ struct Scratch : Generic::Matrix::Scratch<dim>
 namespace PressureConstantMatrices
 {
 
-template<int dim>
-using Copy = Generic::Matrix::MassStiffnessCopy<dim>;
+using Copy = Generic::Matrix::MassStiffnessCopy;
 
 template <int dim>  
 struct Scratch : Generic::Matrix::Scratch<dim>
@@ -154,7 +149,7 @@ struct Scratch : Generic::Matrix::Scratch<dim>
           const FiniteElement<dim>  &fe,
           const UpdateFlags         update_flags);
   
-  Scratch(const Scratch &data);
+  Scratch(const Scratch<dim>        &data);
 
   std::vector<double>         phi;
   
@@ -166,8 +161,7 @@ struct Scratch : Generic::Matrix::Scratch<dim>
 namespace AdvectionMatrix
 {
 
-template<int dim>
-using Copy = Generic::Matrix::Copy<dim>;
+using Copy = Generic::Matrix::Copy;
 
 template <int dim>  
 struct Scratch : Generic::Matrix::Scratch<dim>
@@ -177,7 +171,7 @@ struct Scratch : Generic::Matrix::Scratch<dim>
           const FiniteElement<dim>  &fe,
           const UpdateFlags         update_flags);
 
-  Scratch(const Scratch &data);
+  Scratch(const Scratch<dim>    &data);
 
   /*! @note Should I make it global inside the AssemblyData namespace
       or leave it locally in each struct for readability? */
@@ -207,8 +201,7 @@ struct Scratch : Generic::Matrix::Scratch<dim>
 namespace DiffusionStepRHS
 {
 
-template<int dim>
-using Copy = Generic::RightHandSide::Copy<dim>;
+using Copy = Generic::RightHandSide::Copy;
 
 template <int dim>  
 struct Scratch : ScratchBase<dim>
@@ -224,7 +217,7 @@ struct Scratch : ScratchBase<dim>
           const FiniteElement<dim>  &temperature_fe,
           const UpdateFlags         temperature_update_flags);
   
-  Scratch(const Scratch &data);
+  Scratch(const Scratch<dim>    &data);
 
   using CurlType = typename FEValuesViews::Vector< dim >::curl_type;
 
@@ -301,8 +294,7 @@ struct Scratch : ScratchBase<dim>
 namespace ProjectionStepRHS
 {
 
-template<int dim>
-struct Copy : CopyBase<dim>
+struct Copy : CopyBase
 {
   Copy(const unsigned int dofs_per_cell);
 
@@ -323,7 +315,7 @@ struct Scratch : ScratchBase<dim>
           const FiniteElement<dim>  &pressure_fe,
           const UpdateFlags         pressure_update_flags);
   
-  Scratch(const Scratch &data);
+  Scratch(const Scratch<dim>    &data);
 
   FEValues<dim>       velocity_fe_values;
 
@@ -339,8 +331,7 @@ struct Scratch : ScratchBase<dim>
 namespace PoissonStepRHS
 {
 
-template<int dim>
-using Copy = Generic::RightHandSide::Copy<dim>;
+using Copy = Generic::RightHandSide::Copy;
 
 template <int dim>  
 struct Scratch : ScratchBase<dim>
@@ -358,7 +349,7 @@ struct Scratch : ScratchBase<dim>
           const UpdateFlags         temperature_update_flags,
           const UpdateFlags         temperature_face_update_flags);
   
-  Scratch(const Scratch &data);
+  Scratch(const Scratch<dim>    &data);
 
   using CurlType = typename FEValuesViews::Vector< dim >::curl_type;
 
@@ -425,10 +416,9 @@ namespace HeatEquation
 namespace ConstantMatrices
 {
 
-template<int dim>
-using Copy = Generic::Matrix::MassStiffnessCopy<dim>;
+using Copy = Generic::Matrix::MassStiffnessCopy;
 
-template <int dim>  
+template<int dim>
 struct Scratch : Generic::Matrix::Scratch<dim>
 {
   Scratch(const Mapping<dim>        &mapping,
@@ -436,7 +426,7 @@ struct Scratch : Generic::Matrix::Scratch<dim>
           const FiniteElement<dim>  &fe,
           const UpdateFlags         update_flags);
   
-  Scratch(const Scratch &data);
+  Scratch(const Scratch<dim>    &data);
 
   std::vector<double>         phi;
   
@@ -448,8 +438,7 @@ struct Scratch : Generic::Matrix::Scratch<dim>
 namespace AdvectionMatrix
 {
 
-template<int dim>
-using Copy = Generic::Matrix::Copy<dim>;
+using Copy = Generic::Matrix::Copy;
 
 template <int dim>  
 struct Scratch : ScratchBase<dim>
@@ -461,7 +450,7 @@ struct Scratch : ScratchBase<dim>
           const FiniteElement<dim>  &velocity_fe,
           const UpdateFlags         velocity_update_flags);
   
-  Scratch(const Scratch &data);
+  Scratch(const Scratch<dim>    &data);
 
   FEValues<dim>               temperature_fe_values;
 
@@ -483,8 +472,7 @@ struct Scratch : ScratchBase<dim>
 namespace RightHandSide
 {
 
-template<int dim>
-using Copy = Generic::RightHandSide::Copy<dim>;
+using Copy = Generic::RightHandSide::Copy;
 
 template <int dim>  
 struct Scratch : ScratchBase<dim>
@@ -498,7 +486,7 @@ struct Scratch : ScratchBase<dim>
           const FiniteElement<dim>  &velocity_fe,
           const UpdateFlags         velocity_update_flags);
   
-  Scratch(const Scratch &data);
+  Scratch(const Scratch<dim>    &data);
 
   FEValues<dim>               temperature_fe_values;
 

--- a/include/rotatingMHD/assembly_data.h
+++ b/include/rotatingMHD/assembly_data.h
@@ -19,8 +19,6 @@ struct CopyBase
 {
   CopyBase(const unsigned int dofs_per_cell);
 
-  CopyBase(const CopyBase &data);
-
   unsigned int                          dofs_per_cell;
 
   std::vector<types::global_cell_index> local_dof_indices;
@@ -49,16 +47,12 @@ struct Copy : CopyBase
 {
   Copy(const unsigned int dofs_per_cell);
 
-  Copy(const Copy &data);
-
   FullMatrix<double>  local_matrix;
 };
 
 struct MassStiffnessCopy : CopyBase
 {
   MassStiffnessCopy(const unsigned int dofs_per_cell);
-
-  MassStiffnessCopy(const MassStiffnessCopy &data);
 
   FullMatrix<double>  local_mass_matrix;
 
@@ -86,8 +80,6 @@ namespace RightHandSide
 struct Copy : CopyBase
 {
   Copy(const unsigned int dofs_per_cell);
-
-  Copy(const Copy &data);
 
   Vector<double>      local_rhs;
 
@@ -297,8 +289,6 @@ namespace ProjectionStepRHS
 struct Copy : CopyBase
 {
   Copy(const unsigned int dofs_per_cell);
-
-  Copy(const Copy &data);
 
   Vector<double>      local_projection_step_rhs;
 

--- a/include/rotatingMHD/heat_equation.h
+++ b/include/rotatingMHD/heat_equation.h
@@ -370,31 +370,31 @@ private:
    * @brief This method assembles the mass matrix on a single cell.
    */
   void assemble_local_constant_matrices(
-    const typename DoFHandler<dim>::active_cell_iterator    &cell,
+    const typename DoFHandler<dim>::active_cell_iterator        &cell,
     AssemblyData::HeatEquation::ConstantMatrices::Scratch<dim>  &scratch,
-    AssemblyData::HeatEquation::ConstantMatrices::Copy<dim>     &data);
+    AssemblyData::HeatEquation::ConstantMatrices::Copy          &data);
 
   /*!
    * @brief This method copies the mass matrix into its global
    * conterpart.
    */
   void copy_local_to_global_constant_matrices(
-    const AssemblyData::HeatEquation::ConstantMatrices::Copy<dim>  &data);
+    const AssemblyData::HeatEquation::ConstantMatrices::Copy    &data);
 
   /*!
    * @brief This method assembles the advection matrix on a single cell.
    */
   void assemble_local_advection_matrix(
-    const typename DoFHandler<dim>::active_cell_iterator    &cell,
-    AssemblyData::HeatEquation::AdvectionMatrix::Scratch<dim>  &scratch,
-    AssemblyData::HeatEquation::AdvectionMatrix::Copy<dim>    &data);
+    const typename DoFHandler<dim>::active_cell_iterator        &cell,
+    AssemblyData::HeatEquation::AdvectionMatrix::Scratch<dim>   &scratch,
+    AssemblyData::HeatEquation::AdvectionMatrix::Copy           &data);
 
   /*!
    * @brief This method copies the local advection matrix into their 
    * global conterparts.
    */
   void copy_local_to_global_advection_matrix(
-    const AssemblyData::HeatEquation::AdvectionMatrix::Copy<dim>  &data);
+    const AssemblyData::HeatEquation::AdvectionMatrix::Copy &data);
 
 
   /*!
@@ -403,13 +403,13 @@ private:
   void assemble_local_rhs(
     const typename DoFHandler<dim>::active_cell_iterator    &cell,
     AssemblyData::HeatEquation::RightHandSide::Scratch<dim> &scratch,
-    AssemblyData::HeatEquation::RightHandSide::Copy<dim>    &data);
+    AssemblyData::HeatEquation::RightHandSide::Copy         &data);
   /*!
    * @brief This method copies the local right-hand side into its global
    * conterpart.
    */
   void copy_local_to_global_rhs(
-    const AssemblyData::HeatEquation::RightHandSide::Copy<dim>  &data);
+    const AssemblyData::HeatEquation::RightHandSide::Copy   &data);
 };
 
 template <int dim>

--- a/include/rotatingMHD/navier_stokes_projection.h
+++ b/include/rotatingMHD/navier_stokes_projection.h
@@ -507,16 +507,16 @@ private:
    * matrices of the velocity field on a single cell.
    */
   void assemble_local_velocity_matrices(
-    const typename DoFHandler<dim>::active_cell_iterator  &cell,
-    AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Scratch<dim>  &scratch,
-    AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Copy<dim>     &data);
+    const typename DoFHandler<dim>::active_cell_iterator                        &cell,
+    AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Scratch<dim>&scratch,
+    AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Copy        &data);
 
   /*!
    * @brief This method copies the local mass and the local stiffness matrices
    * of the velocity field on a single cell into the global matrices.
    */
   void copy_local_to_global_velocity_matrices(
-    const AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Copy<dim> &data);
+    const AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Copy  &data);
 
   /*!
    * @brief This method assembles the mass \f$\bs{M}^{(p)}\f$ and the
@@ -542,32 +542,32 @@ private:
    * matrices of the velocity field on a single cell.
    */
   void assemble_local_pressure_matrices(
-    const typename DoFHandler<dim>::active_cell_iterator  &cell,
-    AssemblyData::NavierStokesProjection::PressureConstantMatrices::Scratch<dim>  &scratch,
-    AssemblyData::NavierStokesProjection::PressureConstantMatrices::Copy<dim>     &data);
+    const typename DoFHandler<dim>::active_cell_iterator                        &cell,
+    AssemblyData::NavierStokesProjection::PressureConstantMatrices::Scratch<dim>&scratch,
+    AssemblyData::NavierStokesProjection::PressureConstantMatrices::Copy        &data);
 
   /*!
    * @brief This method copies the local mass and the local stiffness matrices
    * of the pressure field on a single cell into the global matrices.
    */
   void copy_local_to_global_pressure_matrices(
-    const AssemblyData::NavierStokesProjection::PressureConstantMatrices::Copy<dim> &data);
+    const AssemblyData::NavierStokesProjection::PressureConstantMatrices::Copy  &data);
 
   /*!
    * @brief This method assembles the right-hand side of the poisson
    * prestep using the WorkStream approach.
    */
   void assemble_local_poisson_prestep_rhs(
-    const typename DoFHandler<dim>::active_cell_iterator        &cell,
-    AssemblyData::NavierStokesProjection::PoissonStepRHS::Scratch<dim>     &scratch,
-    AssemblyData::NavierStokesProjection::PoissonStepRHS::Copy<dim>       &data);
+    const typename DoFHandler<dim>::active_cell_iterator                &cell,
+    AssemblyData::NavierStokesProjection::PoissonStepRHS::Scratch<dim>  &scratch,
+    AssemblyData::NavierStokesProjection::PoissonStepRHS::Copy          &data);
 
   /*!
    * @brief This method assembles the local right-hand side of the poisson
    * prestep on a single cell.
    */
   void copy_local_to_global_poisson_prestep_rhs(
-    const AssemblyData::NavierStokesProjection::PoissonStepRHS::Copy<dim> &data);
+    const AssemblyData::NavierStokesProjection::PoissonStepRHS::Copy    &data);
 
   /*!
    * @brief This method assembles the right-hand side of the diffusion step
@@ -591,16 +591,16 @@ private:
    * step on a single cell.
    */
   void assemble_local_diffusion_step_rhs(
-    const typename DoFHandler<dim>::active_cell_iterator                  &cell,
-    AssemblyData::NavierStokesProjection::DiffusionStepRHS::Scratch<dim>  &scratch,
-    AssemblyData::NavierStokesProjection::DiffusionStepRHS::Copy<dim>     &data);
+    const typename DoFHandler<dim>::active_cell_iterator                 &cell,
+    AssemblyData::NavierStokesProjection::DiffusionStepRHS::Scratch<dim> &scratch,
+    AssemblyData::NavierStokesProjection::DiffusionStepRHS::Copy         &data);
 
   /*!
    * @brief This method copies the local right-hand side of the diffusion step
    * into the global vector.
    */
   void copy_local_to_global_diffusion_step_rhs(
-    const AssemblyData::NavierStokesProjection::DiffusionStepRHS::Copy<dim> &data);
+    const AssemblyData::NavierStokesProjection::DiffusionStepRHS::Copy  &data);
 
   /*!
    * @brief This method assembles the right-hand side of the projection step
@@ -620,16 +620,16 @@ private:
    * step on a single cell.
    */
   void assemble_local_projection_step_rhs(
-    const typename DoFHandler<dim>::active_cell_iterator                  &cell,
-    AssemblyData::NavierStokesProjection::ProjectionStepRHS::Scratch<dim> &scratch,
-    AssemblyData::NavierStokesProjection::ProjectionStepRHS::Copy<dim>    &data);
+    const typename DoFHandler<dim>::active_cell_iterator                    &cell,
+    AssemblyData::NavierStokesProjection::ProjectionStepRHS::Scratch<dim>   &scratch,
+    AssemblyData::NavierStokesProjection::ProjectionStepRHS::Copy           &data);
 
   /*!
    * @brief This method copies the local right-hand side of the projection step
    * on a single cell to the global vector.
    */
   void copy_local_to_global_projection_step_rhs(
-    const AssemblyData::NavierStokesProjection::ProjectionStepRHS::Copy<dim> &data);
+    const AssemblyData::NavierStokesProjection::ProjectionStepRHS::Copy &data);
 
   /*!
    * @brief This method assembles the velocity advection matrix using the
@@ -656,14 +656,14 @@ private:
   void assemble_local_velocity_advection_matrix(
     const typename DoFHandler<dim>::active_cell_iterator                &cell,
     AssemblyData::NavierStokesProjection::AdvectionMatrix::Scratch<dim> &scratch,
-    AssemblyData::NavierStokesProjection::AdvectionMatrix::Copy<dim>    &data);
+    AssemblyData::NavierStokesProjection::AdvectionMatrix::Copy         &data);
 
   /*!
    * @brief This method copies the local velocity advection matrix into the
    * global matrix.
    */
   void copy_local_to_global_velocity_advection_matrix(
-    const AssemblyData::NavierStokesProjection::AdvectionMatrix::Copy<dim>  &data);
+    const AssemblyData::NavierStokesProjection::AdvectionMatrix::Copy   &data);
   
 };
 

--- a/source/assembly_data.cc
+++ b/source/assembly_data.cc
@@ -21,9 +21,9 @@ local_dof_indices(data.local_dof_indices)
 {}
 
 template <int dim>
-ScratchBase<dim>::ScratchBase(
-  const Quadrature<dim>     &quadrature_formula,
-  const FiniteElement<dim>  &fe)
+ScratchBase<dim>::ScratchBase
+(const Quadrature<dim>     &quadrature_formula,
+ const FiniteElement<dim>  &fe)
 :
 n_q_points(quadrature_formula.size()),
 dofs_per_cell(fe.dofs_per_cell)
@@ -52,7 +52,7 @@ local_matrix(dofs_per_cell, dofs_per_cell)
 template <int dim>
 Copy<dim>::Copy(const Copy &data)
 :
-CopyBase<dim>(data.dofs_per_cell),
+CopyBase<dim>(data),
 local_matrix(data.local_matrix)
 {}
 
@@ -67,7 +67,7 @@ local_stiffness_matrix(dofs_per_cell, dofs_per_cell)
 template <int dim>
 MassStiffnessCopy<dim>::MassStiffnessCopy(const MassStiffnessCopy &data)
 :
-CopyBase<dim>(data.dofs_per_cell),
+CopyBase<dim>(data),
 local_mass_matrix(data.local_mass_matrix),
 local_stiffness_matrix(data.local_stiffness_matrix)
 {}
@@ -91,8 +91,7 @@ template <int dim>
 Scratch<dim>::Scratch(
   const Scratch &data)
 :
-ScratchBase<dim>(data.fe_values.get_quadrature(),
-                 data.fe_values.get_fe()),
+ScratchBase<dim>(data),
 fe_values(data.fe_values.get_mapping(),
           data.fe_values.get_fe(),
           data.fe_values.get_quadrature(),
@@ -115,7 +114,7 @@ local_matrix_for_inhomogeneous_bc(dofs_per_cell, dofs_per_cell)
 template <int dim>
 Copy<dim>::Copy(const Copy &data)
 :
-CopyBase<dim>(data.dofs_per_cell),
+CopyBase<dim>(data),
 local_rhs(data.local_rhs),
 local_matrix_for_inhomogeneous_bc(data.local_matrix_for_inhomogeneous_bc)
 {}
@@ -138,8 +137,7 @@ template <int dim>
 Scratch<dim>::Scratch(
   const Scratch &data)
 :
-ScratchBase<dim>(data.fe_values.get_quadrature(),
-                 data.fe_values.get_fe()),
+ScratchBase<dim>(data),
 fe_values(data.fe_values.get_mapping(),
           data.fe_values.get_fe(),
           data.fe_values.get_quadrature(),

--- a/source/assembly_data.cc
+++ b/source/assembly_data.cc
@@ -28,7 +28,7 @@ dofs_per_cell(fe.dofs_per_cell)
 {}
 
 template <int dim>
-ScratchBase<dim>::ScratchBase(const ScratchBase &data)
+ScratchBase<dim>::ScratchBase(const ScratchBase<dim> &data)
 :
 n_q_points(data.n_q_points),
 dofs_per_cell(data.dofs_per_cell)
@@ -81,8 +81,7 @@ fe_values(mapping,
 {}
 
 template <int dim>
-Scratch<dim>::Scratch(
-  const Scratch &data)
+Scratch<dim>::Scratch(const Scratch<dim> &data)
 :
 ScratchBase<dim>(data),
 fe_values(data.fe_values.get_mapping(),
@@ -125,8 +124,7 @@ fe_values(mapping,
 {}
 
 template <int dim>
-Scratch<dim>::Scratch(
-  const Scratch &data)
+Scratch<dim>::Scratch(const Scratch<dim> &data)
 :
 ScratchBase<dim>(data),
 fe_values(data.fe_values.get_mapping(),

--- a/source/assembly_data.cc
+++ b/source/assembly_data.cc
@@ -12,12 +12,6 @@ dofs_per_cell(dofs_per_cell),
 local_dof_indices(dofs_per_cell)
 {}
 
-CopyBase::CopyBase(const CopyBase &data)
-:
-dofs_per_cell(data.dofs_per_cell),
-local_dof_indices(data.local_dof_indices)
-{}
-
 template <int dim>
 ScratchBase<dim>::ScratchBase(
   const Quadrature<dim>     &quadrature_formula,
@@ -46,24 +40,11 @@ CopyBase(dofs_per_cell),
 local_matrix(dofs_per_cell, dofs_per_cell)
 {}
 
-Copy::Copy(const Copy &data)
-:
-CopyBase(data),
-local_matrix(data.local_matrix)
-{}
-
 MassStiffnessCopy::MassStiffnessCopy(const unsigned int dofs_per_cell)
 :
 CopyBase(dofs_per_cell),
 local_mass_matrix(dofs_per_cell, dofs_per_cell),
 local_stiffness_matrix(dofs_per_cell, dofs_per_cell)
-{}
-
-MassStiffnessCopy::MassStiffnessCopy(const MassStiffnessCopy &data)
-:
-CopyBase(data),
-local_mass_matrix(data.local_mass_matrix),
-local_stiffness_matrix(data.local_stiffness_matrix)
 {}
 
 template <int dim>
@@ -100,13 +81,6 @@ Copy::Copy(const unsigned int dofs_per_cell)
 CopyBase(dofs_per_cell),
 local_rhs(dofs_per_cell),
 local_matrix_for_inhomogeneous_bc(dofs_per_cell, dofs_per_cell)
-{}
-
-Copy::Copy(const Copy &data)
-:
-CopyBase(data),
-local_rhs(data.local_rhs),
-local_matrix_for_inhomogeneous_bc(data.local_matrix_for_inhomogeneous_bc)
 {}
 
 template <int dim>

--- a/source/assembly_data.cc
+++ b/source/assembly_data.cc
@@ -6,24 +6,22 @@ namespace RMHD
 namespace AssemblyData
 {
 
-template <int dim>
-CopyBase<dim>::CopyBase(const unsigned int dofs_per_cell)
+CopyBase::CopyBase(const unsigned int dofs_per_cell)
 :
 dofs_per_cell(dofs_per_cell),
 local_dof_indices(dofs_per_cell)
 {}
 
-template <int dim>
-CopyBase<dim>::CopyBase(const CopyBase &data)
+CopyBase::CopyBase(const CopyBase &data)
 :
 dofs_per_cell(data.dofs_per_cell),
 local_dof_indices(data.local_dof_indices)
 {}
 
 template <int dim>
-ScratchBase<dim>::ScratchBase
-(const Quadrature<dim>     &quadrature_formula,
- const FiniteElement<dim>  &fe)
+ScratchBase<dim>::ScratchBase(
+  const Quadrature<dim>     &quadrature_formula,
+  const FiniteElement<dim>  &fe)
 :
 n_q_points(quadrature_formula.size()),
 dofs_per_cell(fe.dofs_per_cell)
@@ -42,36 +40,31 @@ namespace Generic
 namespace Matrix
 {
 
-template <int dim>
-Copy<dim>::Copy(const unsigned int dofs_per_cell)
+Copy::Copy(const unsigned int dofs_per_cell)
 :
-CopyBase<dim>(dofs_per_cell),
+CopyBase(dofs_per_cell),
 local_matrix(dofs_per_cell, dofs_per_cell)
 {}
 
-template <int dim>
-Copy<dim>::Copy(const Copy &data)
+Copy::Copy(const Copy &data)
 :
-CopyBase<dim>(data),
+CopyBase(data),
 local_matrix(data.local_matrix)
 {}
 
-template <int dim>
-MassStiffnessCopy<dim>::MassStiffnessCopy(const unsigned int dofs_per_cell)
+MassStiffnessCopy::MassStiffnessCopy(const unsigned int dofs_per_cell)
 :
-CopyBase<dim>(dofs_per_cell),
+CopyBase(dofs_per_cell),
 local_mass_matrix(dofs_per_cell, dofs_per_cell),
 local_stiffness_matrix(dofs_per_cell, dofs_per_cell)
 {}
 
-template <int dim>
-MassStiffnessCopy<dim>::MassStiffnessCopy(const MassStiffnessCopy &data)
+MassStiffnessCopy::MassStiffnessCopy(const MassStiffnessCopy &data)
 :
-CopyBase<dim>(data),
+CopyBase(data),
 local_mass_matrix(data.local_mass_matrix),
 local_stiffness_matrix(data.local_stiffness_matrix)
 {}
-
 
 template <int dim>
 Scratch<dim>::Scratch(
@@ -103,18 +96,16 @@ fe_values(data.fe_values.get_mapping(),
 namespace RightHandSide
 {
 
-template <int dim>
-Copy<dim>::Copy(const unsigned int dofs_per_cell)
+Copy::Copy(const unsigned int dofs_per_cell)
 :
-CopyBase<dim>(dofs_per_cell),
+CopyBase(dofs_per_cell),
 local_rhs(dofs_per_cell),
 local_matrix_for_inhomogeneous_bc(dofs_per_cell, dofs_per_cell)
 {}
 
-template <int dim>
-Copy<dim>::Copy(const Copy &data)
+Copy::Copy(const Copy &data)
 :
-CopyBase<dim>(data),
+CopyBase(data),
 local_rhs(data.local_rhs),
 local_matrix_for_inhomogeneous_bc(data.local_matrix_for_inhomogeneous_bc)
 {}
@@ -152,23 +143,11 @@ fe_values(data.fe_values.get_mapping(),
 
 } // namespace RMHD
 
-template struct RMHD::AssemblyData::CopyBase<2>;
-template struct RMHD::AssemblyData::CopyBase<3>;
-
 template struct RMHD::AssemblyData::ScratchBase<2>;
 template struct RMHD::AssemblyData::ScratchBase<3>;
 
-template struct RMHD::AssemblyData::Generic::Matrix::Copy<2>;
-template struct RMHD::AssemblyData::Generic::Matrix::Copy<3>;
-
-template struct RMHD::AssemblyData::Generic::Matrix::MassStiffnessCopy<2>;
-template struct RMHD::AssemblyData::Generic::Matrix::MassStiffnessCopy<3>;
-
 template struct RMHD::AssemblyData::Generic::Matrix::Scratch<2>;
 template struct RMHD::AssemblyData::Generic::Matrix::Scratch<3>;
-
-template struct RMHD::AssemblyData::Generic::RightHandSide::Copy<2>;
-template struct RMHD::AssemblyData::Generic::RightHandSide::Copy<3>;
 
 template struct RMHD::AssemblyData::Generic::RightHandSide::Scratch<2>;
 template struct RMHD::AssemblyData::Generic::RightHandSide::Scratch<3>;

--- a/source/heat_equation/assemble_advection_matrix.cc
+++ b/source/heat_equation/assemble_advection_matrix.cc
@@ -1,4 +1,5 @@
 #include <rotatingMHD/heat_equation.h>
+
 #include <deal.II/base/work_stream.h>
 #include <deal.II/numerics/matrix_tools.h>
 #include <deal.II/grid/filtered_iterator.h>

--- a/source/heat_equation/assemble_advection_matrix.cc
+++ b/source/heat_equation/assemble_advection_matrix.cc
@@ -39,8 +39,8 @@ void HeatEquation<dim>::assemble_advection_matrix()
   // Set up the lamba function for the local assembly operation
   auto worker =
     [this](const typename DoFHandler<dim>::active_cell_iterator     &cell,
-           AssemblyData::HeatEquation::AdvectionMatrix::Scratch<dim>  &scratch,
-           AssemblyData::HeatEquation::AdvectionMatrix::Copy<dim>    &data)
+           AssemblyData::HeatEquation::AdvectionMatrix::Scratch<dim>&scratch,
+           AssemblyData::HeatEquation::AdvectionMatrix::Copy        &data)
     {
       this->assemble_local_advection_matrix(cell, 
                                              scratch,
@@ -49,7 +49,7 @@ void HeatEquation<dim>::assemble_advection_matrix()
 
   // Set up the lamba function for the copy local to global operation
   auto copier =
-    [this](const AssemblyData::HeatEquation::AdvectionMatrix::Copy<dim> &data) 
+    [this](const AssemblyData::HeatEquation::AdvectionMatrix::Copy  &data)
     {
       this->copy_local_to_global_advection_matrix(data);
     };
@@ -75,8 +75,7 @@ void HeatEquation<dim>::assemble_advection_matrix()
     update_quadrature_points,
     *velocity_fe,
     update_values),
-   AssemblyData::HeatEquation::AdvectionMatrix::Copy<dim>(
-     temperature->fe.dofs_per_cell));
+   AssemblyData::HeatEquation::AdvectionMatrix::Copy(temperature->fe.dofs_per_cell));
 
   // Compress global data
   advection_matrix.compress(VectorOperation::add);
@@ -87,9 +86,9 @@ void HeatEquation<dim>::assemble_advection_matrix()
 
 template <int dim>
 void HeatEquation<dim>::assemble_local_advection_matrix
-(const typename DoFHandler<dim>::active_cell_iterator     &cell,
+(const typename DoFHandler<dim>::active_cell_iterator       &cell,
  AssemblyData::HeatEquation::AdvectionMatrix::Scratch<dim>  &scratch,
- AssemblyData::HeatEquation::AdvectionMatrix::Copy<dim>    &data)
+ AssemblyData::HeatEquation::AdvectionMatrix::Copy          &data)
 {
   // Reset local data
   data.local_matrix = 0.;
@@ -164,7 +163,7 @@ void HeatEquation<dim>::assemble_local_advection_matrix
 
 template <int dim>
 void HeatEquation<dim>::copy_local_to_global_advection_matrix
-(const AssemblyData::HeatEquation::AdvectionMatrix::Copy<dim> &data)
+(const AssemblyData::HeatEquation::AdvectionMatrix::Copy    &data)
 {
   temperature->constraints.distribute_local_to_global(
                                       data.local_matrix,
@@ -179,15 +178,15 @@ template void RMHD::HeatEquation<2>::assemble_advection_matrix();
 template void RMHD::HeatEquation<3>::assemble_advection_matrix();
 
 template void RMHD::HeatEquation<2>::assemble_local_advection_matrix
-(const typename DoFHandler<2>::active_cell_iterator  &,
- RMHD::AssemblyData::HeatEquation::AdvectionMatrix::Scratch<2>    &,
- RMHD::AssemblyData::HeatEquation::AdvectionMatrix::Copy<2>      &);
+(const typename DoFHandler<2>::active_cell_iterator             &,
+ RMHD::AssemblyData::HeatEquation::AdvectionMatrix::Scratch<2>  &,
+ RMHD::AssemblyData::HeatEquation::AdvectionMatrix::Copy        &);
 template void RMHD::HeatEquation<3>::assemble_local_advection_matrix
-(const typename DoFHandler<3>::active_cell_iterator  &,
- RMHD::AssemblyData::HeatEquation::AdvectionMatrix::Scratch<3>    &,
- RMHD::AssemblyData::HeatEquation::AdvectionMatrix::Copy<3>      &);
+(const typename DoFHandler<3>::active_cell_iterator             &,
+ RMHD::AssemblyData::HeatEquation::AdvectionMatrix::Scratch<3>  &,
+ RMHD::AssemblyData::HeatEquation::AdvectionMatrix::Copy        &);
 
 template void RMHD::HeatEquation<2>::copy_local_to_global_advection_matrix
-(const RMHD::AssemblyData::HeatEquation::AdvectionMatrix::Copy<2>  &);
+(const RMHD::AssemblyData::HeatEquation::AdvectionMatrix::Copy  &);
 template void RMHD::HeatEquation<3>::copy_local_to_global_advection_matrix
-(const RMHD::AssemblyData::HeatEquation::AdvectionMatrix::Copy<3>  &);
+(const RMHD::AssemblyData::HeatEquation::AdvectionMatrix::Copy  &);

--- a/source/heat_equation/assemble_constant_matrices.cc
+++ b/source/heat_equation/assemble_constant_matrices.cc
@@ -1,4 +1,5 @@
 #include <rotatingMHD/heat_equation.h>
+
 #include <deal.II/base/work_stream.h>
 #include <deal.II/numerics/matrix_tools.h>
 #include <deal.II/grid/filtered_iterator.h>

--- a/source/heat_equation/assemble_constant_matrices.cc
+++ b/source/heat_equation/assemble_constant_matrices.cc
@@ -26,9 +26,9 @@ void HeatEquation<dim>::assemble_constant_matrices()
 
   // Set up the lamba function for the local assembly operation
   auto worker =
-    [this](const typename DoFHandler<dim>::active_cell_iterator     &cell,
-           AssemblyData::HeatEquation::ConstantMatrices::Scratch<dim>  &scratch,
-           AssemblyData::HeatEquation::ConstantMatrices::Copy<dim>    &data)
+    [this](const typename DoFHandler<dim>::active_cell_iterator         &cell,
+           AssemblyData::HeatEquation::ConstantMatrices::Scratch<dim>   &scratch,
+           AssemblyData::HeatEquation::ConstantMatrices::Copy           &data)
     {
       this->assemble_local_constant_matrices(cell, 
                                              scratch,
@@ -37,7 +37,7 @@ void HeatEquation<dim>::assemble_constant_matrices()
 
   // Set up the lamba function for the copy local to global operation
   auto copier =
-    [this](const AssemblyData::HeatEquation::ConstantMatrices::Copy<dim> &data) 
+    [this](const AssemblyData::HeatEquation::ConstantMatrices::Copy &data)
     {
       this->copy_local_to_global_constant_matrices(data);
     };
@@ -60,8 +60,7 @@ void HeatEquation<dim>::assemble_constant_matrices()
     update_values|
     update_gradients|
     update_JxW_values),
-   AssemblyData::HeatEquation::ConstantMatrices::Copy<dim>(
-     temperature->fe.dofs_per_cell));
+   AssemblyData::HeatEquation::ConstantMatrices::Copy(temperature->fe.dofs_per_cell));
 
   // Compress global data
   mass_matrix.compress(VectorOperation::add);
@@ -73,9 +72,9 @@ void HeatEquation<dim>::assemble_constant_matrices()
 
 template <int dim>
 void HeatEquation<dim>::assemble_local_constant_matrices
-(const typename DoFHandler<dim>::active_cell_iterator     &cell,
- AssemblyData::HeatEquation::ConstantMatrices::Scratch<dim>  &scratch,
- AssemblyData::HeatEquation::ConstantMatrices::Copy<dim>    &data)
+(const typename DoFHandler<dim>::active_cell_iterator       &cell,
+ AssemblyData::HeatEquation::ConstantMatrices::Scratch<dim> &scratch,
+ AssemblyData::HeatEquation::ConstantMatrices::Copy         &data)
 {
   // Reset local data
   data.local_mass_matrix      = 0.;
@@ -127,7 +126,7 @@ void HeatEquation<dim>::assemble_local_constant_matrices
 
 template <int dim>
 void HeatEquation<dim>::copy_local_to_global_constant_matrices
-(const AssemblyData::HeatEquation::ConstantMatrices::Copy<dim> &data)
+(const AssemblyData::HeatEquation::ConstantMatrices::Copy   &data)
 {
   temperature->constraints.distribute_local_to_global(
                                       data.local_mass_matrix,
@@ -147,15 +146,15 @@ template void RMHD::HeatEquation<2>::assemble_constant_matrices();
 template void RMHD::HeatEquation<3>::assemble_constant_matrices();
 
 template void RMHD::HeatEquation<2>::assemble_local_constant_matrices
-(const typename DoFHandler<2>::active_cell_iterator  &,
- RMHD::AssemblyData::HeatEquation::ConstantMatrices::Scratch<2>    &,
- RMHD::AssemblyData::HeatEquation::ConstantMatrices::Copy<2>      &);
+(const typename DoFHandler<2>::active_cell_iterator             &,
+ RMHD::AssemblyData::HeatEquation::ConstantMatrices::Scratch<2> &,
+ RMHD::AssemblyData::HeatEquation::ConstantMatrices::Copy       &);
 template void RMHD::HeatEquation<3>::assemble_local_constant_matrices
-(const typename DoFHandler<3>::active_cell_iterator  &,
- RMHD::AssemblyData::HeatEquation::ConstantMatrices::Scratch<3>    &,
- RMHD::AssemblyData::HeatEquation::ConstantMatrices::Copy<3>      &);
+(const typename DoFHandler<3>::active_cell_iterator             &,
+ RMHD::AssemblyData::HeatEquation::ConstantMatrices::Scratch<3> &,
+ RMHD::AssemblyData::HeatEquation::ConstantMatrices::Copy       &);
 
 template void RMHD::HeatEquation<2>::copy_local_to_global_constant_matrices
-(const RMHD::AssemblyData::HeatEquation::ConstantMatrices::Copy<2>  &);
+(const RMHD::AssemblyData::HeatEquation::ConstantMatrices::Copy &);
 template void RMHD::HeatEquation<3>::copy_local_to_global_constant_matrices
-(const RMHD::AssemblyData::HeatEquation::ConstantMatrices::Copy<3>  &);
+(const RMHD::AssemblyData::HeatEquation::ConstantMatrices::Copy &);

--- a/source/heat_equation/assemble_rhs.cc
+++ b/source/heat_equation/assemble_rhs.cc
@@ -1,8 +1,10 @@
 #include <rotatingMHD/heat_equation.h>
+
 #include <deal.II/base/work_stream.h>
 #include <deal.II/numerics/matrix_tools.h>
 #include <deal.II/grid/filtered_iterator.h>
 #include <deal.II/fe/fe_nothing.h>
+
 namespace RMHD
 {
 

--- a/source/heat_equation/assemble_rhs.cc
+++ b/source/heat_equation/assemble_rhs.cc
@@ -55,7 +55,7 @@ void HeatEquation<dim>::assemble_rhs()
   auto worker =
     [this](const typename DoFHandler<dim>::active_cell_iterator     &cell,
            AssemblyData::HeatEquation::RightHandSide::Scratch<dim>  &scratch,
-           AssemblyData::HeatEquation::RightHandSide::Copy<dim>     &data)
+           AssemblyData::HeatEquation::RightHandSide::Copy          &data)
     {
       this->assemble_local_rhs(cell, 
                                scratch,
@@ -64,7 +64,7 @@ void HeatEquation<dim>::assemble_rhs()
 
   // Set up the lamba function for the copy local to global operation
   auto copier =
-    [this](const AssemblyData::HeatEquation::RightHandSide::Copy<dim> &data) 
+    [this](const AssemblyData::HeatEquation::RightHandSide::Copy    &data)
     {
       this->copy_local_to_global_rhs(data);
     };
@@ -94,8 +94,7 @@ void HeatEquation<dim>::assemble_rhs()
     update_quadrature_points,
     *velocity_fe,
     update_values),
-   AssemblyData::HeatEquation::RightHandSide::Copy<dim>(
-     temperature->fe.dofs_per_cell));
+   AssemblyData::HeatEquation::RightHandSide::Copy(temperature->fe.dofs_per_cell));
 
   // Compress global data
   rhs.compress(VectorOperation::add);
@@ -106,9 +105,9 @@ void HeatEquation<dim>::assemble_rhs()
 
 template <int dim>
 void HeatEquation<dim>::assemble_local_rhs(
-  const typename DoFHandler<dim>::active_cell_iterator    &cell,
-  AssemblyData::HeatEquation::RightHandSide::Scratch<dim> &scratch,
-  AssemblyData::HeatEquation::RightHandSide::Copy<dim>    &data)
+  const typename DoFHandler<dim>::active_cell_iterator      &cell,
+  AssemblyData::HeatEquation::RightHandSide::Scratch<dim>   &scratch,
+  AssemblyData::HeatEquation::RightHandSide::Copy           &data)
 {
   // Reset local data
   data.local_rhs                          = 0.;
@@ -359,7 +358,7 @@ void HeatEquation<dim>::assemble_local_rhs(
 
 template <int dim>
 void HeatEquation<dim>::copy_local_to_global_rhs
-(const AssemblyData::HeatEquation::RightHandSide::Copy<dim> &data)
+(const AssemblyData::HeatEquation::RightHandSide::Copy  &data)
 {
   temperature->constraints.distribute_local_to_global(
     data.local_rhs,
@@ -375,16 +374,16 @@ template void RMHD::HeatEquation<2>::assemble_rhs();
 template void RMHD::HeatEquation<3>::assemble_rhs();
 
 template void RMHD::HeatEquation<2>::assemble_local_rhs
-(const typename DoFHandler<2>::active_cell_iterator          &cell,
- RMHD::AssemblyData::HeatEquation::RightHandSide::Scratch<2> &scratch,
- RMHD::AssemblyData::HeatEquation::RightHandSide::Copy<2>    &data);
+(const typename DoFHandler<2>::active_cell_iterator         &,
+ RMHD::AssemblyData::HeatEquation::RightHandSide::Scratch<2>&,
+ RMHD::AssemblyData::HeatEquation::RightHandSide::Copy      &);
 
 template void RMHD::HeatEquation<3>::assemble_local_rhs
-(const typename DoFHandler<3>::active_cell_iterator          &cell,
- RMHD::AssemblyData::HeatEquation::RightHandSide::Scratch<3> &scratch,
- RMHD::AssemblyData::HeatEquation::RightHandSide::Copy<3>    &data);
+(const typename DoFHandler<3>::active_cell_iterator         &,
+ RMHD::AssemblyData::HeatEquation::RightHandSide::Scratch<3>&,
+ RMHD::AssemblyData::HeatEquation::RightHandSide::Copy      &);
 
 template void RMHD::HeatEquation<2>::copy_local_to_global_rhs
-(const RMHD::AssemblyData::HeatEquation::RightHandSide::Copy<2> &);
+(const RMHD::AssemblyData::HeatEquation::RightHandSide::Copy &);
 template void RMHD::HeatEquation<3>::copy_local_to_global_rhs
-(const RMHD::AssemblyData::HeatEquation::RightHandSide::Copy<3> &);
+(const RMHD::AssemblyData::HeatEquation::RightHandSide::Copy &);

--- a/source/heat_equation/assembly_data.cc
+++ b/source/heat_equation/assembly_data.cc
@@ -28,7 +28,7 @@ grad_phi(this->dofs_per_cell)
 {}
 
 template <int dim>
-Scratch<dim>::Scratch(const Scratch &data)
+Scratch<dim>::Scratch(const Scratch<dim> &data)
 :
 Generic::Matrix::Scratch<dim>(data),
 phi(data.dofs_per_cell),
@@ -67,7 +67,7 @@ grad_phi(this->dofs_per_cell)
 {}
 
 template <int dim>
-Scratch<dim>::Scratch(const Scratch &data)
+Scratch<dim>::Scratch(const Scratch<dim> &data)
 :
 ScratchBase<dim>(data),
 temperature_fe_values(data.temperature_fe_values.get_mapping(),
@@ -135,7 +135,7 @@ face_phi(this->dofs_per_cell)
 {}
 
 template <int dim>
-Scratch<dim>::Scratch(const Scratch &data)
+Scratch<dim>::Scratch(const Scratch<dim> &data)
 :
 ScratchBase<dim>(data),
 temperature_fe_values(

--- a/source/navier_stokes_projection/assemble_advection_matrix.cc
+++ b/source/navier_stokes_projection/assemble_advection_matrix.cc
@@ -22,7 +22,7 @@ void NavierStokesProjection<dim>::assemble_velocity_advection_matrix()
   auto worker =
     [this](const typename DoFHandler<dim>::active_cell_iterator                 &cell,
            AssemblyData::NavierStokesProjection::AdvectionMatrix::Scratch<dim>  &scratch,
-           AssemblyData::NavierStokesProjection::AdvectionMatrix::Copy<dim>     &data)
+           AssemblyData::NavierStokesProjection::AdvectionMatrix::Copy          &data)
     {
       this->assemble_local_velocity_advection_matrix(cell, 
                                                      scratch,
@@ -31,7 +31,7 @@ void NavierStokesProjection<dim>::assemble_velocity_advection_matrix()
 
   // Set up the lamba function for the copy local to global operation
   auto copier =
-    [this](const AssemblyData::NavierStokesProjection::AdvectionMatrix::Copy<dim> &data) 
+    [this](const AssemblyData::NavierStokesProjection::AdvectionMatrix::Copy    &data)
     {
       this->copy_local_to_global_velocity_advection_matrix(data);
     };
@@ -54,7 +54,7 @@ void NavierStokesProjection<dim>::assemble_velocity_advection_matrix()
                                          update_values|
                                          update_JxW_values|
                                          update_gradients),
-   AssemblyData::NavierStokesProjection::AdvectionMatrix::Copy<dim>(velocity->fe.dofs_per_cell));
+   AssemblyData::NavierStokesProjection::AdvectionMatrix::Copy(velocity->fe.dofs_per_cell));
 
   // Compress global data
   velocity_advection_matrix.compress(VectorOperation::add);
@@ -64,8 +64,8 @@ void NavierStokesProjection<dim>::assemble_velocity_advection_matrix()
 template <int dim>
 void NavierStokesProjection<dim>::assemble_local_velocity_advection_matrix
 (const typename DoFHandler<dim>::active_cell_iterator  &cell,
- AssemblyData::NavierStokesProjection::AdvectionMatrix::Scratch<dim>  &scratch,
- AssemblyData::NavierStokesProjection::AdvectionMatrix::Copy<dim>     &data)
+ AssemblyData::NavierStokesProjection::AdvectionMatrix::Scratch<dim>&scratch,
+ AssemblyData::NavierStokesProjection::AdvectionMatrix::Copy        &data)
 {
   // Reset local data
   data.local_matrix = 0.;
@@ -220,7 +220,7 @@ void NavierStokesProjection<dim>::assemble_local_velocity_advection_matrix
 
 template <int dim>
 void NavierStokesProjection<dim>::copy_local_to_global_velocity_advection_matrix
-(const AssemblyData::NavierStokesProjection::AdvectionMatrix::Copy<dim> &data)
+(const AssemblyData::NavierStokesProjection::AdvectionMatrix::Copy  &data)
 {
   velocity->constraints.distribute_local_to_global(
                                       data.local_matrix,
@@ -236,14 +236,13 @@ template void RMHD::NavierStokesProjection<3>::assemble_velocity_advection_matri
 template void RMHD::NavierStokesProjection<2>::assemble_local_velocity_advection_matrix
 (const typename DoFHandler<2>::active_cell_iterator                       &,
  RMHD::AssemblyData::NavierStokesProjection::AdvectionMatrix::Scratch<2>  &,
- RMHD::AssemblyData::NavierStokesProjection::AdvectionMatrix::Copy<2>     &);
+ RMHD::AssemblyData::NavierStokesProjection::AdvectionMatrix::Copy        &);
 template void RMHD::NavierStokesProjection<3>::assemble_local_velocity_advection_matrix
 (const typename DoFHandler<3>::active_cell_iterator                       &,
  RMHD::AssemblyData::NavierStokesProjection::AdvectionMatrix::Scratch<3>  &,
- RMHD::AssemblyData::NavierStokesProjection::AdvectionMatrix::Copy<3>     &);
-
+ RMHD::AssemblyData::NavierStokesProjection::AdvectionMatrix::Copy        &);
 
 template void RMHD::NavierStokesProjection<2>::copy_local_to_global_velocity_advection_matrix
-(const RMHD::AssemblyData::NavierStokesProjection::AdvectionMatrix::Copy<2> &);
+(const RMHD::AssemblyData::NavierStokesProjection::AdvectionMatrix::Copy &);
 template void RMHD::NavierStokesProjection<3>::copy_local_to_global_velocity_advection_matrix
-(const RMHD::AssemblyData::NavierStokesProjection::AdvectionMatrix::Copy<3> &);
+(const RMHD::AssemblyData::NavierStokesProjection::AdvectionMatrix::Copy &);

--- a/source/navier_stokes_projection/assemble_diffusion_rhs.cc
+++ b/source/navier_stokes_projection/assemble_diffusion_rhs.cc
@@ -39,7 +39,7 @@ assemble_diffusion_step_rhs()
   auto worker =
     [this](const typename DoFHandler<dim>::active_cell_iterator                 &cell,
            AssemblyData::NavierStokesProjection::DiffusionStepRHS::Scratch<dim> &scratch,
-           AssemblyData::NavierStokesProjection::DiffusionStepRHS::Copy<dim>    &data)
+           AssemblyData::NavierStokesProjection::DiffusionStepRHS::Copy         &data)
     {
       this->assemble_local_diffusion_step_rhs(cell, 
                                               scratch,
@@ -48,7 +48,7 @@ assemble_diffusion_step_rhs()
 
   // Set up the lamba function for the copy local to global operation
   auto copier =
-    [this](const AssemblyData::NavierStokesProjection::DiffusionStepRHS::Copy<dim> &data) 
+    [this](const AssemblyData::NavierStokesProjection::DiffusionStepRHS::Copy   &data)
     {
       this->copy_local_to_global_diffusion_step_rhs(data);
     };
@@ -80,8 +80,7 @@ assemble_diffusion_step_rhs()
      update_values,
      *temperature_fe_ptr,
      update_values),
-   AssemblyData::NavierStokesProjection::DiffusionStepRHS::Copy<dim>(
-     velocity->fe.dofs_per_cell));
+   AssemblyData::NavierStokesProjection::DiffusionStepRHS::Copy(velocity->fe.dofs_per_cell));
 
   // Compress global data
   velocity_rhs.compress(VectorOperation::add);
@@ -94,7 +93,7 @@ template <int dim>
 void NavierStokesProjection<dim>::assemble_local_diffusion_step_rhs
 (const typename DoFHandler<dim>::active_cell_iterator                 &cell,
  AssemblyData::NavierStokesProjection::DiffusionStepRHS::Scratch<dim> &scratch,
- AssemblyData::NavierStokesProjection::DiffusionStepRHS::Copy<dim>    &data)
+ AssemblyData::NavierStokesProjection::DiffusionStepRHS::Copy         &data)
 {
   // Reset local data
   data.local_rhs                          = 0.;
@@ -582,7 +581,7 @@ void NavierStokesProjection<dim>::assemble_local_diffusion_step_rhs
 
 template <int dim>
 void NavierStokesProjection<dim>::copy_local_to_global_diffusion_step_rhs
-(const AssemblyData::NavierStokesProjection::DiffusionStepRHS::Copy<dim>  &data)
+(const AssemblyData::NavierStokesProjection::DiffusionStepRHS::Copy &data)
 {
   velocity->constraints.distribute_local_to_global(
                                 data.local_rhs,
@@ -600,13 +599,13 @@ template void RMHD::NavierStokesProjection<3>::assemble_diffusion_step_rhs();
 template void RMHD::NavierStokesProjection<2>::assemble_local_diffusion_step_rhs
 (const typename DoFHandler<2>::active_cell_iterator                       &,
  RMHD::AssemblyData::NavierStokesProjection::DiffusionStepRHS::Scratch<2> &,
- RMHD::AssemblyData::NavierStokesProjection::DiffusionStepRHS::Copy<2>    &);
+ RMHD::AssemblyData::NavierStokesProjection::DiffusionStepRHS::Copy       &);
 template void RMHD::NavierStokesProjection<3>::assemble_local_diffusion_step_rhs
 (const typename DoFHandler<3>::active_cell_iterator                       &,
  RMHD::AssemblyData::NavierStokesProjection::DiffusionStepRHS::Scratch<3> &,
- RMHD::AssemblyData::NavierStokesProjection::DiffusionStepRHS::Copy<3>    &);
+ RMHD::AssemblyData::NavierStokesProjection::DiffusionStepRHS::Copy       &);
 
 template void RMHD::NavierStokesProjection<2>::copy_local_to_global_diffusion_step_rhs
-(const RMHD::AssemblyData::NavierStokesProjection::DiffusionStepRHS::Copy<2>  &);
+(const RMHD::AssemblyData::NavierStokesProjection::DiffusionStepRHS::Copy &);
 template void RMHD::NavierStokesProjection<3>::copy_local_to_global_diffusion_step_rhs
-(const RMHD::AssemblyData::NavierStokesProjection::DiffusionStepRHS::Copy<3>  &);
+(const RMHD::AssemblyData::NavierStokesProjection::DiffusionStepRHS::Copy &);

--- a/source/navier_stokes_projection/assemble_mass_and_laplace_matrices.cc
+++ b/source/navier_stokes_projection/assemble_mass_and_laplace_matrices.cc
@@ -26,8 +26,8 @@ void NavierStokesProjection<dim>::assemble_velocity_matrices()
   // Set up the lamba function for the local assembly operation
   auto worker =
     [this](const typename DoFHandler<dim>::active_cell_iterator &cell,
-           AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Scratch<dim>         &scratch,
-           AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Copy<dim>           &data)
+           AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Scratch<dim> &scratch,
+           AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Copy         &data)
     {
       this->assemble_local_velocity_matrices(cell, 
                                              scratch,
@@ -36,7 +36,7 @@ void NavierStokesProjection<dim>::assemble_velocity_matrices()
 
   // Set up the lamba function for the copy local to global operation
   auto copier =
-    [this](const AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Copy<dim> &data) 
+    [this](const AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Copy   &data)
     {
       this->copy_local_to_global_velocity_matrices(data);
     };
@@ -59,7 +59,7 @@ void NavierStokesProjection<dim>::assemble_velocity_matrices()
     update_values|
     update_gradients|
     update_JxW_values),
-   AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Copy<dim>(velocity->fe.dofs_per_cell));
+   AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Copy(velocity->fe.dofs_per_cell));
 
   // Compress global data
   velocity_mass_matrix.compress(VectorOperation::add);
@@ -72,8 +72,8 @@ void NavierStokesProjection<dim>::assemble_velocity_matrices()
 template <int dim>
 void NavierStokesProjection<dim>::assemble_local_velocity_matrices
 (const typename DoFHandler<dim>::active_cell_iterator  &cell,
- AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Scratch<dim>          &scratch,
- AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Copy<dim>            &data)
+ AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Scratch<dim>   &scratch,
+ AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Copy           &data)
 {
   // Reset local data
   data.local_mass_matrix = 0.;
@@ -124,7 +124,7 @@ void NavierStokesProjection<dim>::assemble_local_velocity_matrices
 
 template <int dim>
 void NavierStokesProjection<dim>::copy_local_to_global_velocity_matrices
-(const AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Copy<dim> &data)
+(const AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Copy &data)
 {
   velocity->constraints.distribute_local_to_global(
                                       data.local_mass_matrix,
@@ -157,8 +157,8 @@ void NavierStokesProjection<dim>::assemble_pressure_matrices()
   // Set up the lamba function for the local assembly operation
   auto worker =
     [this](const typename DoFHandler<dim>::active_cell_iterator &cell,
-           AssemblyData::NavierStokesProjection::PressureConstantMatrices::Scratch<dim>         &scratch,
-           AssemblyData::NavierStokesProjection::PressureConstantMatrices::Copy<dim>           &data)
+           AssemblyData::NavierStokesProjection::PressureConstantMatrices::Scratch<dim> &scratch,
+           AssemblyData::NavierStokesProjection::PressureConstantMatrices::Copy         &data)
     {
       this->assemble_local_pressure_matrices(cell, 
                                              scratch,
@@ -167,7 +167,7 @@ void NavierStokesProjection<dim>::assemble_pressure_matrices()
   
   // Set up the lamba function for the copy local to global operation
   auto copier =
-    [this](const AssemblyData::NavierStokesProjection::PressureConstantMatrices::Copy<dim> &data) 
+    [this](const AssemblyData::NavierStokesProjection::PressureConstantMatrices::Copy &data)
     {
       this->copy_local_to_global_pressure_matrices(data);
     };
@@ -190,7 +190,7 @@ void NavierStokesProjection<dim>::assemble_pressure_matrices()
     update_values|
     update_gradients|
     update_JxW_values),
-   AssemblyData::NavierStokesProjection::PressureConstantMatrices::Copy<dim>(pressure->fe.dofs_per_cell));
+   AssemblyData::NavierStokesProjection::PressureConstantMatrices::Copy(pressure->fe.dofs_per_cell));
 
   // Compress global data
   pressure_mass_matrix.compress(VectorOperation::add);
@@ -203,8 +203,8 @@ void NavierStokesProjection<dim>::assemble_pressure_matrices()
 template <int dim>
 void NavierStokesProjection<dim>::assemble_local_pressure_matrices
 (const typename DoFHandler<dim>::active_cell_iterator  &cell,
- AssemblyData::NavierStokesProjection::PressureConstantMatrices::Scratch<dim>          &scratch,
- AssemblyData::NavierStokesProjection::PressureConstantMatrices::Copy<dim>            &data)
+ AssemblyData::NavierStokesProjection::PressureConstantMatrices::Scratch<dim>   &scratch,
+ AssemblyData::NavierStokesProjection::PressureConstantMatrices::Copy           &data)
 {
   // Reset local data
   data.local_mass_matrix      = 0.;
@@ -252,7 +252,7 @@ void NavierStokesProjection<dim>::assemble_local_pressure_matrices
 
 template <int dim>
 void NavierStokesProjection<dim>::copy_local_to_global_pressure_matrices
-(const AssemblyData::NavierStokesProjection::PressureConstantMatrices::Copy<dim> &data)
+(const AssemblyData::NavierStokesProjection::PressureConstantMatrices::Copy &data)
 {
   pressure->constraints.distribute_local_to_global(
                                       data.local_mass_matrix,
@@ -272,31 +272,31 @@ template void RMHD::NavierStokesProjection<3>::assemble_velocity_matrices();
 
 template void RMHD::NavierStokesProjection<2>::assemble_local_velocity_matrices
 (const typename DoFHandler<2>::active_cell_iterator  &,
- RMHD::AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Scratch<2>    &,
- RMHD::AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Copy<2>      &);
+ RMHD::AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Scratch<2> &,
+ RMHD::AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Copy       &);
 template void RMHD::NavierStokesProjection<3>::assemble_local_velocity_matrices
 (const typename DoFHandler<3>::active_cell_iterator  &,
- RMHD::AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Scratch<3>    &,
- RMHD::AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Copy<3>      &);
+ RMHD::AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Scratch<3> &,
+ RMHD::AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Copy       &);
 
 template void RMHD::NavierStokesProjection<2>::copy_local_to_global_velocity_matrices
-(const RMHD::AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Copy<2>  &);
+(const RMHD::AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Copy &);
 template void RMHD::NavierStokesProjection<3>::copy_local_to_global_velocity_matrices
-(const RMHD::AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Copy<3>  &);
+(const RMHD::AssemblyData::NavierStokesProjection::VelocityConstantMatrices::Copy &);
 
 template void RMHD::NavierStokesProjection<2>::assemble_pressure_matrices();
 template void RMHD::NavierStokesProjection<3>::assemble_pressure_matrices();
 
 template void RMHD::NavierStokesProjection<2>::assemble_local_pressure_matrices
 (const typename DoFHandler<2>::active_cell_iterator  &,
- RMHD::AssemblyData::NavierStokesProjection::PressureConstantMatrices::Scratch<2>    &,
- RMHD::AssemblyData::NavierStokesProjection::PressureConstantMatrices::Copy<2>      &);
+ RMHD::AssemblyData::NavierStokesProjection::PressureConstantMatrices::Scratch<2> &,
+ RMHD::AssemblyData::NavierStokesProjection::PressureConstantMatrices::Copy       &);
 template void RMHD::NavierStokesProjection<3>::assemble_local_pressure_matrices
 (const typename DoFHandler<3>::active_cell_iterator  &,
- RMHD::AssemblyData::NavierStokesProjection::PressureConstantMatrices::Scratch<3>    &,
- RMHD::AssemblyData::NavierStokesProjection::PressureConstantMatrices::Copy<3>      &);
+ RMHD::AssemblyData::NavierStokesProjection::PressureConstantMatrices::Scratch<3>   &,
+ RMHD::AssemblyData::NavierStokesProjection::PressureConstantMatrices::Copy         &);
 
 template void RMHD::NavierStokesProjection<2>::copy_local_to_global_pressure_matrices
-(const RMHD::AssemblyData::NavierStokesProjection::PressureConstantMatrices::Copy<2>  &);
+(const RMHD::AssemblyData::NavierStokesProjection::PressureConstantMatrices::Copy   &);
 template void RMHD::NavierStokesProjection<3>::copy_local_to_global_pressure_matrices
-(const RMHD::AssemblyData::NavierStokesProjection::PressureConstantMatrices::Copy<3>  &);
+(const RMHD::AssemblyData::NavierStokesProjection::PressureConstantMatrices::Copy   &);

--- a/source/navier_stokes_projection/assemble_poisson_prestep_rhs.cc
+++ b/source/navier_stokes_projection/assemble_poisson_prestep_rhs.cc
@@ -45,8 +45,8 @@ assemble_poisson_prestep_rhs()
   // Set up the lamba function for the local assembly operation
   auto worker =
     [this](const typename DoFHandler<dim>::active_cell_iterator     &cell,
-           AssemblyData::NavierStokesProjection::PoissonStepRHS::Scratch<dim>  &scratch,
-           AssemblyData::NavierStokesProjection::PoissonStepRHS::Copy<dim>    &data)
+           AssemblyData::NavierStokesProjection::PoissonStepRHS::Scratch<dim>   &scratch,
+           AssemblyData::NavierStokesProjection::PoissonStepRHS::Copy           &data)
     {
       this->assemble_local_poisson_prestep_rhs(cell, 
                                                scratch,
@@ -55,7 +55,7 @@ assemble_poisson_prestep_rhs()
 
   // Set up the lamba function for the copy local to global operation
   auto copier =
-    [this](const AssemblyData::NavierStokesProjection::PoissonStepRHS::Copy<dim> &data) 
+    [this](const AssemblyData::NavierStokesProjection::PoissonStepRHS::Copy &data)
     {
       this->copy_local_to_global_poisson_prestep_rhs(data);
     };
@@ -93,8 +93,7 @@ assemble_poisson_prestep_rhs()
       update_values |
       update_gradients,
       update_values),
-    AssemblyData::NavierStokesProjection::PoissonStepRHS::Copy<dim>(
-      pressure->fe.dofs_per_cell));
+    AssemblyData::NavierStokesProjection::PoissonStepRHS::Copy(pressure->fe.dofs_per_cell));
   
   // Compress global data
   poisson_prestep_rhs.compress(VectorOperation::add);
@@ -106,8 +105,8 @@ assemble_poisson_prestep_rhs()
 template <int dim>
 void NavierStokesProjection<dim>::assemble_local_poisson_prestep_rhs
 (const typename DoFHandler<dim>::active_cell_iterator        &cell,
- AssemblyData::NavierStokesProjection::PoissonStepRHS::Scratch<dim>     &scratch,
- AssemblyData::NavierStokesProjection::PoissonStepRHS::Copy<dim>       &data)
+ AssemblyData::NavierStokesProjection::PoissonStepRHS::Scratch<dim> &scratch,
+ AssemblyData::NavierStokesProjection::PoissonStepRHS::Copy         &data)
 {
   // Reset local data
   data.local_rhs = 0.;
@@ -397,7 +396,7 @@ void NavierStokesProjection<dim>::assemble_local_poisson_prestep_rhs
 template <int dim>
 void NavierStokesProjection<dim>::
 copy_local_to_global_poisson_prestep_rhs(
-  const AssemblyData::NavierStokesProjection::PoissonStepRHS::Copy<dim>  &data)
+  const AssemblyData::NavierStokesProjection::PoissonStepRHS::Copy  &data)
 {
   pressure->constraints.distribute_local_to_global(
                                 data.local_rhs,
@@ -411,14 +410,14 @@ copy_local_to_global_poisson_prestep_rhs(
 template void RMHD::NavierStokesProjection<2>::assemble_poisson_prestep_rhs();
 template void RMHD::NavierStokesProjection<3>::assemble_poisson_prestep_rhs();
 template void RMHD::NavierStokesProjection<2>::assemble_local_poisson_prestep_rhs(
-    const typename DoFHandler<2>::active_cell_iterator              &,
-    RMHD::AssemblyData::NavierStokesProjection::PoissonStepRHS::Scratch<2>     &,
-    RMHD::AssemblyData::NavierStokesProjection::PoissonStepRHS::Copy<2>       &);
+    const typename DoFHandler<2>::active_cell_iterator                      &,
+    RMHD::AssemblyData::NavierStokesProjection::PoissonStepRHS::Scratch<2>  &,
+    RMHD::AssemblyData::NavierStokesProjection::PoissonStepRHS::Copy        &);
 template void RMHD::NavierStokesProjection<3>::assemble_local_poisson_prestep_rhs(
-    const typename DoFHandler<3>::active_cell_iterator              &,
-    RMHD::AssemblyData::NavierStokesProjection::PoissonStepRHS::Scratch<3>     &,
-    RMHD::AssemblyData::NavierStokesProjection::PoissonStepRHS::Copy<3>       &);
+    const typename DoFHandler<3>::active_cell_iterator                      &,
+    RMHD::AssemblyData::NavierStokesProjection::PoissonStepRHS::Scratch<3>  &,
+    RMHD::AssemblyData::NavierStokesProjection::PoissonStepRHS::Copy        &);
 template void RMHD::NavierStokesProjection<2>::copy_local_to_global_poisson_prestep_rhs(
-    const RMHD::AssemblyData::NavierStokesProjection::PoissonStepRHS::Copy<2> &);
+    const RMHD::AssemblyData::NavierStokesProjection::PoissonStepRHS::Copy &);
 template void RMHD::NavierStokesProjection<3>::copy_local_to_global_poisson_prestep_rhs(
-    const RMHD::AssemblyData::NavierStokesProjection::PoissonStepRHS::Copy<3> &);
+    const RMHD::AssemblyData::NavierStokesProjection::PoissonStepRHS::Copy &);

--- a/source/navier_stokes_projection/assemble_projection_rhs.cc
+++ b/source/navier_stokes_projection/assemble_projection_rhs.cc
@@ -27,7 +27,7 @@ assemble_projection_step_rhs()
   auto worker =
     [this](const typename DoFHandler<dim>::active_cell_iterator &cell,
            AssemblyData::NavierStokesProjection::ProjectionStepRHS::Scratch<dim>    &scratch,
-           AssemblyData::NavierStokesProjection::ProjectionStepRHS::Copy<dim>      &data)
+           AssemblyData::NavierStokesProjection::ProjectionStepRHS::Copy            &data)
     {
       this->assemble_local_projection_step_rhs(cell, 
                                                scratch,
@@ -36,7 +36,7 @@ assemble_projection_step_rhs()
   
   // Set up the lamba function for the copy local to global operation
   auto copier =
-    [this](const AssemblyData::NavierStokesProjection::ProjectionStepRHS::Copy<dim> &data) 
+    [this](const AssemblyData::NavierStokesProjection::ProjectionStepRHS::Copy  &data)
     {
       this->copy_local_to_global_projection_step_rhs(data);
     };
@@ -60,8 +60,7 @@ assemble_projection_step_rhs()
       pressure->fe,
       update_JxW_values |
       update_values),
-    AssemblyData::NavierStokesProjection::ProjectionStepRHS::Copy<dim>(
-      pressure->fe.dofs_per_cell));
+    AssemblyData::NavierStokesProjection::ProjectionStepRHS::Copy(pressure->fe.dofs_per_cell));
   
   // Compress global data
   pressure_rhs.compress(VectorOperation::add);
@@ -73,8 +72,8 @@ assemble_projection_step_rhs()
 template <int dim>
 void NavierStokesProjection<dim>::assemble_local_projection_step_rhs
 (const typename DoFHandler<dim>::active_cell_iterator  &cell,
- AssemblyData::NavierStokesProjection::ProjectionStepRHS::Scratch<dim>     &scratch,
- AssemblyData::NavierStokesProjection::ProjectionStepRHS::Copy<dim>       &data)
+ AssemblyData::NavierStokesProjection::ProjectionStepRHS::Scratch<dim>  &scratch,
+ AssemblyData::NavierStokesProjection::ProjectionStepRHS::Copy          &data)
 {
   // Reset local data
   data.local_projection_step_rhs = 0.;
@@ -130,7 +129,7 @@ void NavierStokesProjection<dim>::assemble_local_projection_step_rhs
 template <int dim>
 void NavierStokesProjection<dim>::
 copy_local_to_global_projection_step_rhs(
-  const AssemblyData::NavierStokesProjection::ProjectionStepRHS::Copy<dim>  &data)
+  const AssemblyData::NavierStokesProjection::ProjectionStepRHS::Copy   &data)
 {
   pressure->constraints.distribute_local_to_global
   (data.local_projection_step_rhs,
@@ -147,13 +146,13 @@ template void RMHD::NavierStokesProjection<3>::assemble_projection_step_rhs();
 template void RMHD::NavierStokesProjection<2>::assemble_local_projection_step_rhs
 (const typename DoFHandler<2>::active_cell_iterator                         &,
  RMHD::AssemblyData::NavierStokesProjection::ProjectionStepRHS::Scratch<2>  &,
- RMHD::AssemblyData::NavierStokesProjection::ProjectionStepRHS::Copy<2>     &);
+ RMHD::AssemblyData::NavierStokesProjection::ProjectionStepRHS::Copy        &);
 template void RMHD::NavierStokesProjection<3>::assemble_local_projection_step_rhs
 (const typename DoFHandler<3>::active_cell_iterator                         &,
  RMHD::AssemblyData::NavierStokesProjection::ProjectionStepRHS::Scratch<3>  &,
- RMHD::AssemblyData::NavierStokesProjection::ProjectionStepRHS::Copy<3>     &);
+ RMHD::AssemblyData::NavierStokesProjection::ProjectionStepRHS::Copy        &);
 
 template void RMHD::NavierStokesProjection<2>::copy_local_to_global_projection_step_rhs
-(const RMHD::AssemblyData::NavierStokesProjection::ProjectionStepRHS::Copy<2> &);
+(const RMHD::AssemblyData::NavierStokesProjection::ProjectionStepRHS::Copy &);
 template void RMHD::NavierStokesProjection<3>::copy_local_to_global_projection_step_rhs
-(const RMHD::AssemblyData::NavierStokesProjection::ProjectionStepRHS::Copy<3> &);
+(const RMHD::AssemblyData::NavierStokesProjection::ProjectionStepRHS::Copy &);

--- a/source/navier_stokes_projection/assembly_data.cc
+++ b/source/navier_stokes_projection/assembly_data.cc
@@ -243,18 +243,16 @@ face_phi(this->dofs_per_cell)
 namespace ProjectionStepRHS
 {
 
-template <int dim>
-Copy<dim>::Copy(const unsigned int dofs_per_cell)
+Copy::Copy(const unsigned int dofs_per_cell)
 :
-CopyBase<dim>(dofs_per_cell),
+CopyBase(dofs_per_cell),
 local_projection_step_rhs(dofs_per_cell),
 local_correction_step_rhs(dofs_per_cell)
 {}
 
-template <int dim>
-Copy<dim>::Copy(const Copy &data)
+Copy::Copy(const Copy &data)
 :
-CopyBase<dim>(data),
+CopyBase(data),
 local_projection_step_rhs(data.local_projection_step_rhs),
 local_correction_step_rhs(data.local_correction_step_rhs)
 {}
@@ -452,9 +450,6 @@ template struct RMHD::AssemblyData::NavierStokesProjection::AdvectionMatrix::Scr
 
 template struct RMHD::AssemblyData::NavierStokesProjection::DiffusionStepRHS::Scratch<2>;
 template struct RMHD::AssemblyData::NavierStokesProjection::DiffusionStepRHS::Scratch<3>;
-
-template struct RMHD::AssemblyData::NavierStokesProjection::ProjectionStepRHS::Copy<2>;
-template struct RMHD::AssemblyData::NavierStokesProjection::ProjectionStepRHS::Copy<3>;
 
 template struct RMHD::AssemblyData::NavierStokesProjection::ProjectionStepRHS::Scratch<2>;
 template struct RMHD::AssemblyData::NavierStokesProjection::ProjectionStepRHS::Scratch<3>;

--- a/source/navier_stokes_projection/assembly_data.cc
+++ b/source/navier_stokes_projection/assembly_data.cc
@@ -250,13 +250,6 @@ local_projection_step_rhs(dofs_per_cell),
 local_correction_step_rhs(dofs_per_cell)
 {}
 
-Copy::Copy(const Copy &data)
-:
-CopyBase(data),
-local_projection_step_rhs(data.local_projection_step_rhs),
-local_correction_step_rhs(data.local_correction_step_rhs)
-{}
-
 template <int dim>
 Scratch<dim>::Scratch
 (const Mapping<dim>        &mapping,

--- a/source/navier_stokes_projection/assembly_data.cc
+++ b/source/navier_stokes_projection/assembly_data.cc
@@ -37,7 +37,7 @@ grad_phi(this->dofs_per_cell)
 {}
 
 template <int dim>
-Scratch<dim>::Scratch(const Scratch &data)
+Scratch<dim>::Scratch(const Scratch<dim> &data)
 :
 Generic::Matrix::Scratch<dim>(data),
 phi(data.dofs_per_cell),
@@ -65,7 +65,7 @@ grad_phi(this->dofs_per_cell)
 {}
 
 template <int dim>
-Scratch<dim>::Scratch(const Scratch &data)
+Scratch<dim>::Scratch(const Scratch<dim> &data)
 :
 Generic::Matrix::Scratch<dim>(data),
 phi(data.dofs_per_cell),
@@ -100,7 +100,7 @@ curl_phi(this->dofs_per_cell)
 {}
 
 template <int dim>
-Scratch<dim>::Scratch(const Scratch &data)
+Scratch<dim>::Scratch(const Scratch<dim> &data)
 :
 Generic::Matrix::Scratch<dim>(data),
 old_velocity_values(data.n_q_points),
@@ -185,7 +185,7 @@ face_phi(this->dofs_per_cell)
 {}
 
 template <int dim>
-Scratch<dim>::Scratch(const Scratch &data)
+Scratch<dim>::Scratch(const Scratch<dim> &data)
 :
 ScratchBase<dim>(data),
 velocity_fe_values(
@@ -283,7 +283,7 @@ phi(this->dofs_per_cell)
 {}
 
 template <int dim>
-Scratch<dim>::Scratch(const Scratch &data)
+Scratch<dim>::Scratch(const Scratch<dim> &data)
 :
 ScratchBase<dim>(data),
 velocity_fe_values(
@@ -375,7 +375,7 @@ face_phi(this->dofs_per_cell)
 {}
 
 template <int dim>
-Scratch<dim>::Scratch(const Scratch &data)
+Scratch<dim>::Scratch(const Scratch<dim> &data)
 :
 ScratchBase<dim>(data),
 velocity_fe_values(


### PR DESCRIPTION
This PR fixes warnings due to an implicit declaration of copy-assignment operators. This warning is due to the so-called rule of three. The problems is fixed by removing unnecessary copy-constructors which are equivalent to ones automatically generated by the compiler. Then, the warnings disappear. See https://www.cplusplus.com/articles/y8hv0pDG/ and https://en.cppreference.com/w/cpp/language/rule_of_three.

- No physics was changed.
- `Copy` objects are no longer `template<int dim> struct`s because this is not necessary.
- Copy-constructors of `Scratch` objects is now correctly declared and implemented as `Scratch(const Scratch<dim> &data)`.
