### PR TITLE
Compilability with PETSc and catching of the ILU preconditioner in parallel

### DIFF
--- a/include/rotatingMHD/global.h
+++ b/include/rotatingMHD/global.h
@@ -27,7 +27,7 @@ namespace LinearAlgebra
 #if defined(DEAL_II_WITH_PETSC) && !defined(DEAL_II_PETSC_WITH_COMPLEX) && \
   !(defined(DEAL_II_WITH_TRILINOS) && defined(FORCE_USE_OF_TRILINOS))
   using namespace dealii::LinearAlgebraPETSc;
-  using PreconditionBase = dealii::PETScWrappers::PreconditionBase;;
+  using PreconditionBase = dealii::PETScWrappers::PreconditionerBase;
   #define USE_PETSC_LA
 #elif defined(DEAL_II_WITH_TRILINOS)
   using namespace dealii::LinearAlgebraTrilinos;

--- a/source/utility.cc
+++ b/source/utility.cc
@@ -19,6 +19,13 @@ void build_preconditioner
   {
     case (PreconditionerType::ILU):
     {
+      #ifdef USE_PETSC_LA
+        AssertThrow(Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD) == 1,
+                    ExcMessage("PreconditionILU using the PETSc library "
+                                "only works in serial. Please choose a different"
+                                " preconditioner."));
+      #endif
+
       LinearAlgebra::MPI::PreconditionILU::AdditionalData preconditioner_data;
 
       const PreconditionILUParameters* preconditioner_parameters
@@ -58,12 +65,12 @@ void build_preconditioner
         preconditioner_data.aggregation_threshold = preconditioner_parameters->aggregation_threshold;
       #endif
 
-        preconditioner =
-          std::make_shared<LinearAlgebra::MPI::PreconditionAMG>();
+      preconditioner =
+        std::make_shared<LinearAlgebra::MPI::PreconditionAMG>();
 
-        static_cast<LinearAlgebra::MPI::PreconditionAMG*>(preconditioner.get())
-            ->initialize(matrix,
-                         preconditioner_data);
+      static_cast<LinearAlgebra::MPI::PreconditionAMG*>(preconditioner.get())
+          ->initialize(matrix,
+                       preconditioner_data);
       break;
     }
     case (PreconditionerType::SSOR):


### PR DESCRIPTION
Resolves issue #60.

The program throws an exception as follows if executed in parallel using the ILU preconditioner:
```
----------------------------------------------------
Exception on processing: 

--------------------------------------------------------
An error occurred in line <611> of file </home/sg/Documents/Projects/RotatingMHD/source/run_time_parameters.cc> in function
    RMHD::RunTimeParameters::PreconditionILUParameters::PreconditionILUParameters()
The violated condition was: 
    Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD) == 1
Additional information: 
    PreconditionILU using the PETSc library only works in serial. Please choose a different preconditioner.
--------------------------------------------------------
```
However, on my machine the ILU preconditioner is still missing but that is another thing.
```
[0]PETSC ERROR: --------------------- Error Message --------------------------------------------------------------
[0]PETSC ERROR: See https://www.mcs.anl.gov/petsc/documentation/linearsolvertable.html for possible LU and Cholesky solvers
[0]PETSC ERROR: Could not locate a solver package for factorization type ILU and matrix type mpiaij.
[0]PETSC ERROR: See https://www.mcs.anl.gov/petsc/documentation/faq.html for trouble shooting.
[0]PETSC ERROR: Petsc Release Version 3.12.5, Mar, 29, 2020 
[0]PETSC ERROR: ./DFG on a  named corona by sg Thu Feb 11 23:51:28 2021
[0]PETSC ERROR: Configure options --with-shared-libraries=1 --with-x=0 --with-mpi=1 --download-hypre=1 --with-debugging=0 --prefix=/usr/local/petsc-3.12.5
[0]PETSC ERROR: #1 MatGetFactor() line 4416 in /home/sg/Downloads/Software/petsc-3.12.5/src/mat/interface/matrix.c
[0]PETSC ERROR: #2 PCSetUp_ILU() line 133 in /home/sg/Downloads/Software/petsc-3.12.5/src/ksp/pc/impls/factor/ilu/ilu.c
[0]PETSC ERROR: #3 PCSetUp() line 894 in /home/sg/Downloads/Software/petsc-3.12.5/src/ksp/pc/interface/precon.c
```