### PR TITLE
Mean value constraint in the NavierStokesProjection solver

### DIFF
--- a/applications/MIT.cc
+++ b/applications/MIT.cc
@@ -274,8 +274,11 @@ void MITBenchmark<dim>::setup_constraints()
   velocity->boundary_conditions.set_dirichlet_bcs(3);
   velocity->boundary_conditions.set_dirichlet_bcs(4);
 
-  // The pressure itself has no boundary conditions. The Navier-Stokes
-  // solver will constrain by setting its mean value to zero.
+  // The pressure itself has no boundary conditions, leading to a pure
+  // Neumann problem. A datum ensures the well-posedness of the problem
+  // and The Navier-Stokes solver will enforce a zero mean value
+  // constraint.
+  pressure->boundary_conditions.set_datum_at_boundary();
 
   // Inhomogeneous time dependent Dirichlet boundary conditions over
   // the side walls and homogeneous Neumann boundary conditions over
@@ -284,8 +287,6 @@ void MITBenchmark<dim>::setup_constraints()
     1, temperature_boundary_conditions, true);
   temperature->boundary_conditions.set_dirichlet_bcs(
     2, temperature_boundary_conditions, true);
-
-  pressure->boundary_conditions.set_datum_at_boundary();
 
   velocity->apply_boundary_conditions();
 

--- a/applications/MIT.cc
+++ b/applications/MIT.cc
@@ -285,6 +285,8 @@ void MITBenchmark<dim>::setup_constraints()
   temperature->boundary_conditions.set_dirichlet_bcs(
     2, temperature_boundary_conditions, true);
 
+  pressure->boundary_conditions.set_datum_at_boundary();
+
   velocity->apply_boundary_conditions();
 
   pressure->apply_boundary_conditions();

--- a/include/rotatingMHD/boundary_conditions.h
+++ b/include/rotatingMHD/boundary_conditions.h
@@ -110,12 +110,6 @@ public:
   std::vector<PeriodicBoundaryData<dim>>    periodic_bcs;
 
   /*!
-   * A flag indicating that a local degree of freedom at the boundary
-   * is to be set to zero.
-   */
-  bool                                      flag_datum_at_boundary;
-
-  /*!
    * @brief A multimap of boundary condition types and boundary ids
    * which were mark as having a time-dependent function.
    */
@@ -126,6 +120,16 @@ public:
    * unconstrained boundaries.
    */
   std::vector<types::boundary_id> get_unconstrained_boundary_ids();
+
+  /*!
+   * A method returning the value of @ref flag_datum_at_boundary.
+   */
+  bool                            is_a_datum_set_at_boundary() const;
+
+  /*!
+   * A method returning the value of @ref flag_regularity_guaranteed.
+   */
+  bool                            is_regularity_guaranteed() const;
 
 protected:
   /*!
@@ -150,7 +154,35 @@ protected:
    * extracted.
    */
   bool                                            flag_extract_boundary_ids;
+
+  /*!
+   * A flag indicating that a local degree of freedom at the boundary
+   * is to be set to zero.
+   */
+  bool                                            flag_datum_at_boundary;
+
+  /*!
+   * A flag indicating that boundary conditions fulfill the
+   * necessary conditions for a well-posed problem.
+   */
+  bool                                            flag_regularity_guaranteed;
 };
+
+
+
+template <int dim>
+inline bool BoundaryConditionsBase<dim>::is_a_datum_set_at_boundary() const
+{
+  return (flag_datum_at_boundary);
+}
+
+
+
+template <int dim>
+inline bool BoundaryConditionsBase<dim>::is_regularity_guaranteed() const
+{
+  return (flag_regularity_guaranteed);
+}
 
 /*!
  * @struct ScalarBoundaryConditions

--- a/include/rotatingMHD/boundary_conditions.h
+++ b/include/rotatingMHD/boundary_conditions.h
@@ -70,7 +70,8 @@ enum class BCType
   dirichlet,
   neumann,
   normal_flux,
-  tangential_flux
+  tangential_flux,
+  datum_at_boundary
 };
 
 /*!
@@ -107,6 +108,12 @@ public:
    * to be applied as boundary conditions.
    */
   std::vector<PeriodicBoundaryData<dim>>    periodic_bcs;
+
+  /*!
+   * A flag indicating that a local degree of freedom at the boundary
+   * is to be set to zero.
+   */
+  bool                                      flag_datum_at_boundary;
 
   /*!
    * @brief A multimap of boundary condition types and boundary ids
@@ -218,6 +225,12 @@ struct ScalarBoundaryConditions : BoundaryConditionsBase<dim>
                          = std::shared_ptr<Function<dim>>(),
                        const bool                           time_depedent
                          = false);
+
+  /*!
+   * @brief Sets an admissible local degree of freedom at the boundary
+   * to zero
+   */
+  void set_datum_at_boundary();
 
   /*!
    * @brief This method sets the time of the functions by calling their

--- a/include/rotatingMHD/boundary_conditions.h
+++ b/include/rotatingMHD/boundary_conditions.h
@@ -124,12 +124,12 @@ public:
   /*!
    * A method returning the value of @ref flag_datum_at_boundary.
    */
-  bool                            is_a_datum_set_at_boundary() const;
+  bool                            datum_set_at_boundary() const;
 
   /*!
    * A method returning the value of @ref flag_regularity_guaranteed.
    */
-  bool                            is_regularity_guaranteed() const;
+  bool                            regularity_guaranteed() const;
 
 protected:
   /*!
@@ -146,6 +146,8 @@ protected:
 
   /*!
    * @brief Reference to the underlying triangulation.
+   * @todo Change it to a shared_ptr if copy constructure are allowed
+   * through the change.
    */
   const parallel::distributed::Triangulation<dim> &triangulation;
 
@@ -156,8 +158,9 @@ protected:
   bool                                            flag_extract_boundary_ids;
 
   /*!
-   * A flag indicating that a local degree of freedom at the boundary
-   * is to be set to zero.
+   * A flag indicating that a single degree of freedom is constrained
+   * at the boundary. This is required to obtain a regular system matrix
+   * in case of a pure Neumann problem.
    */
   bool                                            flag_datum_at_boundary;
 
@@ -171,7 +174,7 @@ protected:
 
 
 template <int dim>
-inline bool BoundaryConditionsBase<dim>::is_a_datum_set_at_boundary() const
+inline bool BoundaryConditionsBase<dim>::datum_set_at_boundary() const
 {
   return (flag_datum_at_boundary);
 }
@@ -179,7 +182,7 @@ inline bool BoundaryConditionsBase<dim>::is_a_datum_set_at_boundary() const
 
 
 template <int dim>
-inline bool BoundaryConditionsBase<dim>::is_regularity_guaranteed() const
+inline bool BoundaryConditionsBase<dim>::regularity_guaranteed() const
 {
   return (flag_regularity_guaranteed);
 }

--- a/include/rotatingMHD/equation_data.h
+++ b/include/rotatingMHD/equation_data.h
@@ -236,6 +236,8 @@ public:
                                   const unsigned int component) const;
 };
 
+/*! @todo Add a mean value method that considers both domains of the
+    Guermond problem*/
 template <int dim>
 class PressureExactSolution : public Function<dim>
 {

--- a/source/boundary_conditions.cc
+++ b/source/boundary_conditions.cc
@@ -26,9 +26,10 @@ template <int dim>
 BoundaryConditionsBase<dim>::BoundaryConditionsBase(
   const parallel::distributed::Triangulation<dim> &triangulation)
 :
-flag_datum_at_boundary(false),
 triangulation(triangulation),
-flag_extract_boundary_ids(true)
+flag_extract_boundary_ids(true),
+flag_datum_at_boundary(false),
+flag_regularity_guaranteed(false)
 {}
 
 template <int dim>
@@ -83,6 +84,8 @@ void ScalarBoundaryConditions<dim>::set_periodic_bcs(
                                   direction,
                                   rotation_matrix,
                                   offset);
+
+  this->flag_regularity_guaranteed = true;
 }
 
 template <int dim>
@@ -107,6 +110,8 @@ void ScalarBoundaryConditions<dim>::set_dirichlet_bcs(
 
   if (time_dependent)
     this->time_dependent_bcs_map.emplace(BCType::dirichlet, boundary_id);
+
+  this->flag_regularity_guaranteed = true;
 }
 
 template <int dim>
@@ -132,6 +137,8 @@ void ScalarBoundaryConditions<dim>::set_neumann_bcs(
 
   if (time_dependent)
     this->time_dependent_bcs_map.emplace(BCType::neumann, boundary_id);
+
+  this->flag_regularity_guaranteed = true;
 }
 
 
@@ -139,7 +146,8 @@ void ScalarBoundaryConditions<dim>::set_neumann_bcs(
 template <int dim>
 void ScalarBoundaryConditions<dim>::set_datum_at_boundary()
 {
-  this->flag_datum_at_boundary = true;
+  this->flag_datum_at_boundary      = true;
+  this->flag_regularity_guaranteed  = true;
 }
 
 
@@ -170,10 +178,11 @@ template <int dim>
 void ScalarBoundaryConditions<dim>::copy
 (const ScalarBoundaryConditions<dim> &other)
 {
-  this->dirichlet_bcs           = other.dirichlet_bcs;
-  this->neumann_bcs             = other.neumann_bcs;
-  this->periodic_bcs            = other.periodic_bcs;
-  this->time_dependent_bcs_map  = other.time_dependent_bcs_map;
+  this->dirichlet_bcs               = other.dirichlet_bcs;
+  this->neumann_bcs                 = other.neumann_bcs;
+  this->periodic_bcs                = other.periodic_bcs;
+  this->time_dependent_bcs_map      = other.time_dependent_bcs_map;
+  this->flag_regularity_guaranteed  = other.flag_regularity_guaranteed;
 }
 
 template <int dim>
@@ -240,6 +249,8 @@ void VectorBoundaryConditions<dim>::set_periodic_bcs(
                                   direction,
                                   rotation_matrix,
                                   offset);
+
+  this->flag_regularity_guaranteed = true;
 }
 
 template <int dim>
@@ -268,6 +279,8 @@ void VectorBoundaryConditions<dim>::set_dirichlet_bcs(
 
   if (time_dependent)
     this->time_dependent_bcs_map.emplace(BCType::dirichlet, boundary_id);
+
+  this->flag_regularity_guaranteed = true;
 }
 
 template <int dim>
@@ -293,6 +306,8 @@ void VectorBoundaryConditions<dim>::set_neumann_bcs(
 
   if (time_dependent)
     this->time_dependent_bcs_map.emplace(BCType::neumann, boundary_id);
+
+  this->flag_regularity_guaranteed = true;
 }
 
 template <int dim>
@@ -321,6 +336,9 @@ void VectorBoundaryConditions<dim>::set_normal_flux_bcs(
 
   if (time_dependent)
     this->time_dependent_bcs_map.emplace(BCType::normal_flux, boundary_id);
+
+  /*! @attention I am not sure if this passes a fully constrained */
+  this->flag_regularity_guaranteed = true;
 }
 
 template <int dim>
@@ -349,6 +367,9 @@ void VectorBoundaryConditions<dim>::set_tangential_flux_bcs(
 
   if (time_dependent)
     this->time_dependent_bcs_map.emplace(BCType::tangential_flux, boundary_id);
+
+  /*! @attention I am not sure if this passes a fully constrained */
+  this->flag_regularity_guaranteed = true;
 }
 
 template <int dim>
@@ -382,12 +403,13 @@ template <int dim>
 void VectorBoundaryConditions<dim>::copy(
   const VectorBoundaryConditions<dim> &other)
 {
-  this->dirichlet_bcs           = other.dirichlet_bcs;
-  this->neumann_bcs             = other.neumann_bcs;
-  this->periodic_bcs            = other.periodic_bcs;
-  this->time_dependent_bcs_map  = other.time_dependent_bcs_map;
-  normal_flux_bcs               = other.normal_flux_bcs;
-  tangential_flux_bcs           = other.tangential_flux_bcs;
+  this->dirichlet_bcs               = other.dirichlet_bcs;
+  this->neumann_bcs                 = other.neumann_bcs;
+  this->periodic_bcs                = other.periodic_bcs;
+  this->time_dependent_bcs_map      = other.time_dependent_bcs_map;
+  normal_flux_bcs                   = other.normal_flux_bcs;
+  tangential_flux_bcs               = other.tangential_flux_bcs;
+  this->flag_regularity_guaranteed  = other.flag_regularity_guaranteed;
 }
 
 template <int dim>

--- a/source/boundary_conditions.cc
+++ b/source/boundary_conditions.cc
@@ -137,8 +137,6 @@ void ScalarBoundaryConditions<dim>::set_neumann_bcs(
 
   if (time_dependent)
     this->time_dependent_bcs_map.emplace(BCType::neumann, boundary_id);
-
-  this->flag_regularity_guaranteed = true;
 }
 
 

--- a/source/boundary_conditions.cc
+++ b/source/boundary_conditions.cc
@@ -26,6 +26,7 @@ template <int dim>
 BoundaryConditionsBase<dim>::BoundaryConditionsBase(
   const parallel::distributed::Triangulation<dim> &triangulation)
 :
+flag_datum_at_boundary(false),
 triangulation(triangulation),
 flag_extract_boundary_ids(true)
 {}
@@ -132,6 +133,16 @@ void ScalarBoundaryConditions<dim>::set_neumann_bcs(
   if (time_dependent)
     this->time_dependent_bcs_map.emplace(BCType::neumann, boundary_id);
 }
+
+
+
+template <int dim>
+void ScalarBoundaryConditions<dim>::set_datum_at_boundary()
+{
+  this->flag_datum_at_boundary = true;
+}
+
+
 
 template <int dim>
 void ScalarBoundaryConditions<dim>::set_time(const double time)

--- a/source/boundary_conditions.cc
+++ b/source/boundary_conditions.cc
@@ -247,6 +247,8 @@ void ScalarBoundaryConditions<dim>::set_dirichlet_bcs(
   const std::shared_ptr<Function<dim>> &function,
   const bool                           time_dependent)
 {
+  AssertThrow(!this->flag_datum_at_boundary,
+              ExcMessage("A datum was already set at the boundary. It is not needed if Dirichlet boundary conditions are to be set."))
   check_boundary_id(boundary_id);
 
   this->constrained_boundaries.push_back(boundary_id);
@@ -298,6 +300,9 @@ void ScalarBoundaryConditions<dim>::set_neumann_bcs(
 template <int dim>
 void ScalarBoundaryConditions<dim>::set_datum_at_boundary()
 {
+  AssertThrow(this->dirichlet_bcs.empty(),
+              ExcMessage("Dirichlet boundary conditions were set. A datum is not needed."));
+
   this->flag_datum_at_boundary      = true;
   this->flag_regularity_guaranteed  = true;
 }

--- a/source/entities_structs.cc
+++ b/source/entities_structs.cc
@@ -122,7 +122,7 @@ void VectorEntity<dim>::setup_dofs()
 template <int dim>
 void VectorEntity<dim>::apply_boundary_conditions()
 {
-  AssertThrow(boundary_conditions.is_regularity_guaranteed(),
+  AssertThrow(boundary_conditions.regularity_guaranteed(),
               ExcMessage("No boundary conditions were set for the \""
                           + this->name + "\" entity"));
 
@@ -213,50 +213,8 @@ void VectorEntity<dim>::apply_boundary_conditions()
       this->constraints);
   }
 
-  /*! @attention This is commented out as I am not sure if this would
-      constraint a component or the whole vector*/
-  /*
-  if (boundary_conditions.is_a_datum_set_at_boundary())
-  {
-    IndexSet    boundary_dofs;
-    DoFTools::extract_boundary_dofs(*this->dof_handler,
-                                    ComponentMask(this->fe.n_components(), true),
-                                    boundary_dofs);
+  /*! @todo Implement a datum for vector valued problem*/
 
-    // Looks for an admissible local degree of freedom to constrain
-    types::global_dof_index local_idx = numbers::invalid_dof_index;
-    IndexSet::ElementIterator idx = boundary_dofs.begin();
-    IndexSet::ElementIterator endidx = boundary_dofs.end();
-    for(; idx != endidx; ++idx)
-      if (this->constraints.can_store_line(*idx) &&
-          !this->constraints.is_constrained(*idx))
-      {
-        local_idx = *idx;
-        break;
-      }
-
-    // Chooses the degree of freedom with the smallest index. If no
-    // admissible degree of freedom was found in a given processor, its
-    // value is set the number of degree of freedom
-    const types::global_dof_index global_idx
-      = Utilities::MPI::min((local_idx != numbers::invalid_dof_index)
-                              ? local_idx
-                              : this->dof_handler->n_dofs(),
-                             this->mpi_communicator);
-
-    // Checks that an admissable degree of freedom was found
-    Assert(global_idx < this->dof_handler->n_dofs(),
-           ExcMessage("Error, couldn't find a DoF to constrain."));
-
-    // Sets the degree of freedom to zero
-    if (this->constraints.can_store_line(global_idx))
-    {
-        Assert(!this->constraints.is_constrained(global_idx),
-               ExcInternalError());
-        this->constraints.add_line(global_idx);
-    }
-  }
-  */
   this->constraints.close();
 }
 
@@ -497,7 +455,7 @@ void ScalarEntity<dim>::setup_dofs()
 template <int dim>
 void ScalarEntity<dim>::apply_boundary_conditions()
 {
-  AssertThrow(boundary_conditions.is_regularity_guaranteed(),
+  AssertThrow(boundary_conditions.regularity_guaranteed(),
               ExcMessage("No boundary conditions were set for the \""
                           + this->name + "\" entity"));
 
@@ -541,7 +499,7 @@ void ScalarEntity<dim>::apply_boundary_conditions()
       this->constraints);
   }
 
-  if (boundary_conditions.is_a_datum_set_at_boundary())
+  if (boundary_conditions.datum_set_at_boundary())
   {
     IndexSet    boundary_dofs;
     DoFTools::extract_boundary_dofs(*this->dof_handler,

--- a/source/entities_structs.cc
+++ b/source/entities_structs.cc
@@ -209,6 +209,51 @@ void VectorEntity<dim>::apply_boundary_conditions()
       this->constraints);
   }
 
+  /*! @attention This is commented out as I am not sure if this would
+      constraint a component or the whole vector*/
+  /*
+  if (boundary_conditions.flag_datum_at_boundary)
+  {
+    IndexSet    boundary_dofs;
+    DoFTools::extract_boundary_dofs(*this->dof_handler,
+                                    ComponentMask(this->fe.n_components(), true),
+                                    boundary_dofs);
+
+    types::global_dof_index local_idx = numbers::invalid_dof_index;
+    IndexSet::ElementIterator idx = boundary_dofs.begin();
+    IndexSet::ElementIterator endidx = boundary_dofs.end();
+    for(; idx != endidx; ++idx)
+      if (this->constraints.can_store_line(*idx) &&
+          !this->constraints.is_constrained(*idx))
+      {
+        local_idx = *idx;
+        break;
+      }
+    // Make a reduction to find the smallest index (processors that
+    // found a larger candidate just happened to not be able to store
+    // that index with the minimum value). Note that it is possible that
+    // some processors might not be able to find a potential DoF, for
+    // example because they don't own any DoFs. On those processors we
+    // will use dof_handler.n_dofs() when building the minimum (larger
+    // than any valid DoF index).
+    const types::global_dof_index global_idx
+      = Utilities::MPI::min((local_idx != numbers::invalid_dof_index)
+                              ? local_idx
+                              : this->dof_handler->n_dofs(),
+                            this->mpi_communicator);
+
+    Assert(global_idx < this->dof_handler->n_dofs(),
+           ExcMessage("Error, couldn't find a DoF to constrain."));
+
+    // Finally set this DoF to zero (if we care about it):
+    if (this->constraints.can_store_line(global_idx))
+    {
+        Assert(!this->constraints.is_constrained(global_idx),
+               ExcInternalError());
+        this->constraints.add_line(global_idx);
+    }
+  }
+  */
   this->constraints.close();
 }
 
@@ -488,6 +533,49 @@ void ScalarEntity<dim>::apply_boundary_conditions()
       function_map,
       this->constraints);
   }
+
+  if (boundary_conditions.flag_datum_at_boundary)
+  {
+    IndexSet    boundary_dofs;
+    DoFTools::extract_boundary_dofs(*this->dof_handler,
+                                    ComponentMask(this->fe.n_components(), true),
+                                    boundary_dofs);
+
+    types::global_dof_index local_idx = numbers::invalid_dof_index;
+    IndexSet::ElementIterator idx = boundary_dofs.begin();
+    IndexSet::ElementIterator endidx = boundary_dofs.end();
+    for(; idx != endidx; ++idx)
+      if (this->constraints.can_store_line(*idx) &&
+          !this->constraints.is_constrained(*idx))
+      {
+        local_idx = *idx;
+        break;
+      }
+    // Make a reduction to find the smallest index (processors that
+    // found a larger candidate just happened to not be able to store
+    // that index with the minimum value). Note that it is possible that
+    // some processors might not be able to find a potential DoF, for
+    // example because they don't own any DoFs. On those processors we
+    // will use dof_handler.n_dofs() when building the minimum (larger
+    // than any valid DoF index).
+    const types::global_dof_index global_idx
+      = Utilities::MPI::min((local_idx != numbers::invalid_dof_index)
+                              ? local_idx
+                              : this->dof_handler->n_dofs(),
+                            this->mpi_communicator);
+
+    Assert(global_idx < this->dof_handler->n_dofs(),
+           ExcMessage("Error, couldn't find a DoF to constrain."));
+
+    // Finally set this DoF to zero (if we care about it):
+    if (this->constraints.can_store_line(global_idx))
+    {
+        Assert(!this->constraints.is_constrained(global_idx),
+               ExcInternalError());
+        this->constraints.add_line(global_idx);
+    }
+  }
+
   this->constraints.close();
 }
 

--- a/source/navier_stokes_projection/poisson_prestep_methods.cc
+++ b/source/navier_stokes_projection/poisson_prestep_methods.cc
@@ -98,10 +98,19 @@ solve_poisson_prestep()
 
   pressure->constraints.distribute(distributed_old_pressure);
 
-  if (flag_normalize_pressure)
-    VectorTools::subtract_mean_value(distributed_old_pressure);
-
   pressure->old_solution = distributed_old_pressure;
+
+  if (flag_normalize_pressure)
+  {
+    const LinearAlgebra::MPI::Vector::value_type mean_value
+      = VectorTools::compute_mean_value(*pressure->dof_handler,
+                                        QGauss<dim>(pressure->fe.degree + 1),
+                                        pressure->old_solution,
+                                        0);
+
+    distributed_old_pressure.add(-mean_value);
+    pressure->old_solution = distributed_old_pressure;
+  }
 
   if (parameters.verbose)
     *pcout << " done!" << std::endl

--- a/source/navier_stokes_projection/solve.cc
+++ b/source/navier_stokes_projection/solve.cc
@@ -163,6 +163,8 @@ void NavierStokesProjection<dim>::pressure_correction(const bool reinit_prec)
           // boundary conditions on the pressure field.
           if (!pressure->boundary_conditions.dirichlet_bcs.empty())
             pressure->constraints.distribute(distributed_pressure);
+          else
+            pressure->hanging_nodes.distribute(distributed_pressure);
 
           // Pass the distributed vector to its ghost counterpart.
           pressure->solution = distributed_pressure;
@@ -180,9 +182,6 @@ void NavierStokesProjection<dim>::pressure_correction(const bool reinit_prec)
             distributed_pressure.add(-mean_value);
             pressure->solution = distributed_pressure;
           }
-            //VectorTools::subtract_mean_value(distributed_pressure);
-
-
 
           if (parameters.verbose)
                 *pcout << " done!" << std::endl

--- a/source/navier_stokes_projection/solve.cc
+++ b/source/navier_stokes_projection/solve.cc
@@ -161,15 +161,28 @@ void NavierStokesProjection<dim>::pressure_correction(const bool reinit_prec)
           // The pressure's constraints are distributed to the
           // solution vector to consider the case of Dirichlet
           // boundary conditions on the pressure field.
-          pressure->constraints.distribute(distributed_pressure);
+          if (!pressure->boundary_conditions.dirichlet_bcs.empty())
+            pressure->constraints.distribute(distributed_pressure);
+
+          // Pass the distributed vector to its ghost counterpart.
+          pressure->solution = distributed_pressure;
 
           // If the pressure field is defined only up to a constant,
           // a zero mean value constraint is enforced
           if (flag_normalize_pressure)
-            VectorTools::subtract_mean_value(distributed_pressure);
+          {
+            const LinearAlgebra::MPI::Vector::value_type mean_value
+              = VectorTools::compute_mean_value(*pressure->dof_handler,
+                                                QGauss<dim>(pressure->fe.degree + 1),
+                                                pressure->solution,
+                                                0);
 
-          // Pass the distributed vector to its ghost counterpart.
-          pressure->solution = distributed_pressure;
+            distributed_pressure.add(-mean_value);
+            pressure->solution = distributed_pressure;
+          }
+            //VectorTools::subtract_mean_value(distributed_pressure);
+
+
 
           if (parameters.verbose)
                 *pcout << " done!" << std::endl

--- a/source/problem_class.cc
+++ b/source/problem_class.cc
@@ -143,39 +143,24 @@ void Problem<dim>::compute_error(
   std::shared_ptr<Entities::EntityBase<dim>>  entity,
   Function<dim>                               &exact_solution)
 {
-  #ifdef USE_PETSC_LA
-    LinearAlgebra::MPI::Vector
-    tmp_error_vector(entity->locally_owned_dofs, mpi_communicator);
-  #else
-    LinearAlgebra::MPI::Vector
-    tmp_error_vector(entity->locally_owned_dofs);
-  #endif
-  VectorTools::project(*entity->dof_handler,
-                       entity->constraints,
-                       QGauss<dim>(entity->fe_degree + 2),
-                       exact_solution,
-                       tmp_error_vector);
+  AssertThrow(error_vector.local_size() ==
+                entity->solution.local_size(),
+              ExcMessage("The vectors do not match in size"));
 
-  error_vector = tmp_error_vector;
+  LinearAlgebra::MPI::Vector  distributed_solution_vector;
+  LinearAlgebra::MPI::Vector  distributed_error_vector;
 
-  LinearAlgebra::MPI::Vector distributed_error_vector;
-  LinearAlgebra::MPI::Vector distributed_solution;
+  distributed_solution_vector.reinit(entity->distributed_vector);
+  distributed_error_vector.reinit(entity->distributed_vector);
 
-  #ifdef USE_PETSC_LA
-    distributed_error_vector.reinit(entity->locally_owned_dofs,
-                                    mpi_communicator);
-  #else
-    distributed_error_vector.reinit(entity->locally_owned_dofs,
-                                    entity->locally_relevant_dofs,
-                                    mpi_communicator,
-                                    true);
-  #endif
-  distributed_solution.reinit(distributed_error_vector);
+  distributed_solution_vector = entity->solution;
+  VectorTools::interpolate(*mapping,
+                           *entity->dof_handler,
+                           exact_solution,
+                           distributed_error_vector);
+  entity->hanging_nodes.distribute(distributed_error_vector);
 
-  distributed_error_vector  = error_vector;
-  distributed_solution      = entity->solution;
-
-  distributed_error_vector.add(-1.0, distributed_solution);
+  distributed_error_vector.add(-1.0, distributed_solution_vector);
 
   for (unsigned int i = distributed_error_vector.local_range().first;
        i < distributed_error_vector.local_range().second; ++i)


### PR DESCRIPTION
Added 
- Member and method related to setting up a datum, i. e. set a random degree of freedom to zero, to the field
- Member and method to check for regularity before applying constriants
- Changed all `subtract_mean_value` to `compute_mean_value`
- Cleaned up methods shifting the pressure field for it to match the mean value of the analytical solution in `Guermond`.

To-do
- Add an assertion if Dirichlet boundary conditions and a datum are tried to be applied at the same time

I'd prefer to fix the problems described in #76 before merging this into `master` 