### PR TITLE
Proposed format changes on the terminal output of preconditioner and boundary conditions

### DIFF
--- a/applications/MIT.cc
+++ b/applications/MIT.cc
@@ -138,13 +138,16 @@ Problem<dim>(parameters),
 params(parameters),
 velocity(std::make_shared<Entities::VectorEntity<dim>>(
               parameters.fe_degree_velocity,
-              this->triangulation)),
+              this->triangulation,
+              "Velocity")),
 pressure(std::make_shared<Entities::ScalarEntity<dim>>(
               parameters.fe_degree_pressure,
-              this->triangulation)),
+              this->triangulation,
+              "Pressure")),
 temperature(std::make_shared<Entities::ScalarEntity<dim>>(
               parameters.fe_degree_temperature,
-              this->triangulation)),
+              this->triangulation,
+              "Temperature")),
 temperature_boundary_conditions(
               std::make_shared<EquationData::MIT::TemperatureBoundaryCondition<dim>>(
               parameters.time_discretization_parameters.start_time)),
@@ -287,6 +290,8 @@ void MITBenchmark<dim>::setup_constraints()
     1, temperature_boundary_conditions, true);
   temperature->boundary_conditions.set_dirichlet_bcs(
     2, temperature_boundary_conditions, true);
+  temperature->boundary_conditions.set_neumann_bcs(3);
+  temperature->boundary_conditions.set_neumann_bcs(4);
 
   velocity->apply_boundary_conditions();
 

--- a/include/rotatingMHD/run_time_parameters.h
+++ b/include/rotatingMHD/run_time_parameters.h
@@ -937,7 +937,7 @@ struct LinearSolverParameters
   /*!
    * Constructor which sets up the parameters with default values.
    */
-  LinearSolverParameters();
+  LinearSolverParameters(const std::string &name = "default");
 
   /*!
    * @brief Static method which declares the associated parameter to the

--- a/source/boundary_conditions.cc
+++ b/source/boundary_conditions.cc
@@ -18,10 +18,11 @@ namespace Entities
 
 namespace internal
 {
-  constexpr char header[] = "+----------------------+"
-      "------------------------------------------+";
+  constexpr char header[] = "+---------+"
+                            "------------+"
+                            "------------------------------------------+";
 
-  constexpr size_t column_width[2] = { 20, 40 };
+  constexpr size_t column_width[3] = { 7, 10, 40};
 
   constexpr size_t line_width = 63;
 
@@ -36,16 +37,19 @@ namespace internal
            << std::endl;
   }
 
-  template<typename Stream, typename A, typename B>
+  template<typename Stream, typename A, typename B, typename C>
   void add_line(Stream  &stream,
                 const A &first_column,
-                const B &second_column)
+                const B &second_column,
+                const C &third_column)
   {
     stream << "| "
            << std::setw(column_width[0]) << first_column
            << " | "
            << std::setw(column_width[1]) << second_column
-           << " |"
+           << " | "
+           << std::setw(column_width[2]) << third_column
+          << " |"
            << std::endl;
   }
 
@@ -137,36 +141,32 @@ void BoundaryConditionsBase<dim>::print_summary
 (Stream &stream)
 {
   if (dirichlet_bcs.size() != 0)
-  {
-    internal::add_line(stream, "Dirichlet boundary conditions");
-    internal::add_line(stream, "Boundary id", "   Type name");
-
     for(auto &[key, value]: this->dirichlet_bcs)
       internal::add_line(stream,
                          key,
+                         "Dirichlet",
                          internal::get_type_string(*value));
-  }
 
   if (periodic_bcs.size() != 0)
-  {
-    internal::add_line(stream, "Periodic boundary conditions");
-    internal::add_line(stream, "1st id", "2nd id");
-
     for(const PeriodicBoundaryData<dim> &periodic_bc: this->periodic_bcs)
       internal::add_line(stream,
-                         periodic_bc.boundary_pair.first,
-                         periodic_bc.boundary_pair.second);
-  }
+                         std::to_string(periodic_bc.boundary_pair.first) + ", " +
+                         std::to_string(periodic_bc.boundary_pair.second),
+                         "Periodic",
+                         "---");
 
   const std::vector<types::boundary_id> unconstrained_boundary_ids
     = get_unconstrained_boundary_ids();
+
   if (unconstrained_boundary_ids.size() != 0)
   {
-    internal::add_line(stream, "Unconstrained boundary ids");
-
     std::stringstream strstream;
+    strstream << "Unconstrained boundary ids: ";
     for(const auto &boundary_id: unconstrained_boundary_ids)
       strstream << boundary_id << ", ";
+
+    strstream.seekp(-2, strstream.cur);
+    strstream << " ";
 
     internal::add_line(stream, strstream.str().c_str());
   }
@@ -201,19 +201,22 @@ void ScalarBoundaryConditions<dim>::print_summary
 
   internal::add_header(stream);
 
-  BoundaryConditionsBase<dim>::print_summary(stream);
+  internal::add_line(stream,
+                     "Bdy. id",
+                     "   Type",
+                     "             Function");
 
   if (neumann_bcs.size() != 0)
-  {
-    internal::add_line(stream, "Neumann boundary conditions");
-
-    internal::add_line(stream, "Boundary id", "   Type name");
-
     for(const auto &[key, value]: neumann_bcs)
       internal::add_line(stream,
                          key,
+                         "Neumann",
                          internal::get_type_string(*value));
-  }
+
+  if (this->flag_datum_at_boundary)
+    internal::add_line(stream, "A datum has been set at the boundary");
+
+  BoundaryConditionsBase<dim>::print_summary(stream);
 
   internal::add_header(stream);
 }
@@ -335,10 +338,12 @@ template <int dim>
 void ScalarBoundaryConditions<dim>::copy
 (const ScalarBoundaryConditions<dim> &other)
 {
+  this->constrained_boundaries      = other.constrained_boundaries;
   this->dirichlet_bcs               = other.dirichlet_bcs;
   this->neumann_bcs                 = other.neumann_bcs;
   this->periodic_bcs                = other.periodic_bcs;
   this->time_dependent_bcs_map      = other.time_dependent_bcs_map;
+  this->flag_datum_at_boundary      = other.flag_datum_at_boundary;
   this->flag_regularity_guaranteed  = other.flag_regularity_guaranteed;
 }
 
@@ -406,37 +411,33 @@ void VectorBoundaryConditions<dim>::print_summary
 
   internal::add_header(stream);
 
-  BoundaryConditionsBase<dim>::print_summary(stream);
+  internal::add_line(stream,
+                     "Bdy. id",
+                     "   Type",
+                     "             Function");
 
   if (neumann_bcs.size() != 0)
-  {
-    internal::add_line(stream, "Neumann boundary conditions");
-    internal::add_line(stream, "Boundary id", "   Type name");
     for(const auto &[key, value]: this->neumann_bcs)
       internal::add_line(stream,
                          key,
+                         "Neumann",
                          internal::get_type_string(*value));
-  }
 
   if (normal_flux_bcs.size() != 0)
-  {
-    internal::add_line(stream, "Normal flux boundary conditions");
-    internal::add_line(stream, "   Boundary id", "   Type name");
     for(const auto &[key, value]: normal_flux_bcs)
       internal::add_line(stream,
                          key,
+                         "Norm. flux",
                          internal::get_type_string(*value));
-  }
 
   if (tangential_flux_bcs.size() != 0)
-  {
-    internal::add_line(stream, "Tangential flux boundary conditions");
-    internal::add_line(stream, "   Boundary id", "   Type name");
     for(const auto &[key, value]: tangential_flux_bcs)
       internal::add_line(stream,
                          key,
+                         "Tang. flux",
                          internal::get_type_string(*value)  );
-  }
+
+  BoundaryConditionsBase<dim>::print_summary(stream);
 
   internal::add_header(stream);
 }
@@ -615,6 +616,7 @@ template <int dim>
 void VectorBoundaryConditions<dim>::copy(
   const VectorBoundaryConditions<dim> &other)
 {
+  this->constrained_boundaries      = other.constrained_boundaries;
   this->dirichlet_bcs               = other.dirichlet_bcs;
   this->neumann_bcs                 = other.neumann_bcs;
   this->periodic_bcs                = other.periodic_bcs;

--- a/source/navier_stokes_projection.cc
+++ b/source/navier_stokes_projection.cc
@@ -78,7 +78,7 @@ NavierStokesProjection<dim>::NavierStokesProjection
  const std::shared_ptr<ConditionalOStream>        external_pcout,
  const std::shared_ptr<TimerOutput>               external_timer)
 :
-phi(std::make_shared<Entities::ScalarEntity<dim>>(*pressure)),
+phi(std::make_shared<Entities::ScalarEntity<dim>>(*pressure, "Phi")),
 parameters(parameters),
 mpi_communicator(velocity->mpi_communicator),
 velocity(velocity),

--- a/source/navier_stokes_projection/setup.cc
+++ b/source/navier_stokes_projection/setup.cc
@@ -99,6 +99,11 @@ void NavierStokesProjection<dim>::setup_phi()
   for (auto &neumann_bc : velocity->boundary_conditions.neumann_bcs)
     phi->boundary_conditions.set_dirichlet_bcs(neumann_bc.first);
 
+  // The remaining unconstrained boundaries in the phi space are set to
+  // homogeneous Neumann boundary conditions
+  for (const auto &unconstrained_boundary_id: phi->boundary_conditions.get_unconstrained_boundary_ids())
+    phi->boundary_conditions.set_neumann_bcs(unconstrained_boundary_id);
+
   // Apply boundary conditions
   phi->apply_boundary_conditions();
 

--- a/source/run_time_parameters.cc
+++ b/source/run_time_parameters.cc
@@ -513,8 +513,6 @@ void PreconditionRelaxationParameters::parse_parameters(const ParameterHandler &
 {
   PreconditionBaseParameters::parse_parameters(prm);
 
-  /*! @attetion I added the OR. Otherwise one can not choose SSOR. Or is there a reason
-      for only asserting for Jacobi? */
   AssertThrow(preconditioner_type == PreconditionerType::Jacobi ||
               preconditioner_type == PreconditionerType::SSOR,
               ExcMessage("Unexpected preconditioner type in "
@@ -736,7 +734,7 @@ void PreconditionAMGParameters::parse_parameters(const ParameterHandler &prm)
   n_cycles = prm.get_integer("Number of cycles");
   AssertThrow(n_cycles > 0,
               ExcLowerRange(n_cycles, 1));
-  AssertIsFinite(aggregation_threshold);
+  AssertIsFinite(n_cycles);
 
   aggregation_threshold = prm.get_double("Aggregation threshold");
   AssertThrow(aggregation_threshold > 0.0,


### PR DESCRIPTION
Linear solver parameters look like this
```
+------------------------------------------+----------------------+
| Linear solver parameters - Poisson pre-step                     |
+------------------------------------------+----------------------+
| Maximum number of iterations             | 1000                 |
| Relative tolerance                       | 1e-06                |
| Absolute tolerance                       | 1e-09                |
| Preconditioner                           | ILU                  |
|   Fill-in level                          | 2                    |
|   Overlap                                | 2                    |
|   Relative tolerance                     | 1.01                 |
|   Absolute tolerance                     | 1e-05                |
+------------------------------------------+----------------------+
```
and boundary conditions look for `MIT.cc` like this
```
+---------+------------+------------------------------------------+
| Boundary conditions of the Velocity entity                      |
+---------+------------+------------------------------------------+
| Bdy. id |    Type    |              Function                    |
| 1       | Dirichlet  | ZeroFunction<2, double>                  |
| 2       | Dirichlet  | ZeroFunction<2, double>                  |
| 3       | Dirichlet  | ZeroFunction<2, double>                  |
| 4       | Dirichlet  | ZeroFunction<2, double>                  |
+---------+------------+------------------------------------------+
+---------+------------+------------------------------------------+
| Boundary conditions of the Pressure entity                      |
+---------+------------+------------------------------------------+
| Bdy. id |    Type    |              Function                    |
| A datum has been set at the boundary                            |
| Unconstrained boundary ids: 1, 2, 3, 4                          |
+---------+------------+------------------------------------------+
+---------+------------+------------------------------------------+
| Boundary conditions of the Temperature entity                   |
+---------+------------+------------------------------------------+
| Bdy. id |    Type    |              Function                    |
| 3       | Neumann    | ZeroFunction<2, double>                  |
| 4       | Neumann    | ZeroFunction<2, double>                  |
| 1       | Dirichlet  | MIT::TemperatureBoundaryCondition<2>     |
| 2       | Dirichlet  | MIT::TemperatureBoundaryCondition<2>     |
+---------+------------+------------------------------------------+
+---------+------------+------------------------------------------+
| Boundary conditions of the Phi entity                           |
+---------+------------+------------------------------------------+
| Bdy. id |    Type    |              Function                    |
| 1       | Neumann    | ZeroFunction<2, double>                  |
| 2       | Neumann    | ZeroFunction<2, double>                  |
| 3       | Neumann    | ZeroFunction<2, double>                  |
| 4       | Neumann    | ZeroFunction<2, double>                  |
| A datum has been set at the boundary                            |
+---------+------------+------------------------------------------+
```
and for `Couette.cc` like this
```
+---------+------------+------------------------------------------+
| Boundary conditions of the Velocity entity                      |
+---------+------------+------------------------------------------+
| Bdy. id |    Type    |              Function                    |
| 3       | Neumann    | Couette::TractionVector<2>               |
| 2       | Dirichlet  | ZeroFunction<2, double>                  |
| 0, 1    | Periodic   | ---                                      |
+---------+------------+------------------------------------------+
+---------+------------+------------------------------------------+
| Boundary conditions of the Pressure entity                      |
+---------+------------+------------------------------------------+
| Bdy. id |    Type    |              Function                    |
| 0, 1    | Periodic   | ---                                      |
| Unconstrained boundary ids: 2, 3                                |
+---------+------------+------------------------------------------+
+---------+------------+------------------------------------------+
| Boundary conditions of the Phi entity                           |
+---------+------------+------------------------------------------+
| Bdy. id |    Type    |              Function                    |
| 2       | Neumann    | ZeroFunction<2, double>                  |
| 3       | Dirichlet  | ZeroFunction<2, double>                  |
| 0, 1    | Periodic   | ---                                      |
+---------+------------+------------------------------------------+
```
for example. This was my proposal in #75 