### PR TITLE
Build advection related preconditioners in the second step

### DIFF
--- a/source/heat_equation/solve.cc
+++ b/source/heat_equation/solve.cc
@@ -19,7 +19,8 @@ void HeatEquation<dim>::solve()
 
   solve_linear_system(flag_matrices_were_updated ||
                       time_stepping.get_step_number() %
-                      parameters.preconditioner_update_frequency == 0);
+                      parameters.preconditioner_update_frequency == 0 ||
+                      time_stepping.get_step_number() == 1);
 
   flag_matrices_were_updated = false;
 }

--- a/source/navier_stokes_projection/solve.cc
+++ b/source/navier_stokes_projection/solve.cc
@@ -24,7 +24,8 @@ void NavierStokesProjection<dim>::solve()
   else
   {
     diffusion_step(time_stepping.get_step_number() %
-                   parameters.preconditioner_update_frequency == 0);
+                   parameters.preconditioner_update_frequency == 0) ||
+                   time_stepping.get_step_number() == 1);
 
     projection_step(false);
 

--- a/source/navier_stokes_projection/solve.cc
+++ b/source/navier_stokes_projection/solve.cc
@@ -24,7 +24,7 @@ void NavierStokesProjection<dim>::solve()
   else
   {
     diffusion_step(time_stepping.get_step_number() %
-                   parameters.preconditioner_update_frequency == 0) ||
+                   parameters.preconditioner_update_frequency == 0 ||
                    time_stepping.get_step_number() == 1);
 
     projection_step(false);


### PR DESCRIPTION
While testing the AMG preconditioners the solvers keep diverging in the second step. My reasoning was that due to the zero velocity initial condition the preconditioner built during the first step doesn't consider the matrix entries related to the advection term. Rebuilding the preconditioner during the second step fixes this.