### PR TITLE
Fix tolerance values

### DIFF
--- a/applications/Christensen.prm
+++ b/applications/Christensen.prm
@@ -24,9 +24,9 @@ subsection Heat equation solver parameters
 
 
   subsection Linear solver parameters
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 1000
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -50,9 +50,9 @@ subsection Navier-Stokes solver parameters
 
 
   subsection Linear solver parameters - Correction step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 1000
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -65,9 +65,9 @@ subsection Navier-Stokes solver parameters
   end
 
   subsection Linear solver parameters - Diffusion step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 1000
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -80,9 +80,9 @@ subsection Navier-Stokes solver parameters
   end
 
   subsection Linear solver parameters - Poisson pre-step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 1000
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -95,9 +95,9 @@ subsection Navier-Stokes solver parameters
   end
 
   subsection Linear solver parameters - Projection step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 1000
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters

--- a/applications/Couette.cc
+++ b/applications/Couette.cc
@@ -325,10 +325,6 @@ void Couette<dim>::solve(const unsigned int &level)
     // Compute CFL number
     cfl_number = navier_stokes.get_cfl_number();
 
-    // Updates the time step, i.e sets the value of t^{k}
-    time_stepping.set_desired_next_step_size(
-      this->compute_next_time_step(time_stepping, cfl_number));
-
     // Updates the coefficients to their k-th value
     time_stepping.update_coefficients();
 

--- a/applications/Couette.prm
+++ b/applications/Couette.prm
@@ -30,9 +30,9 @@ subsection Navier-Stokes solver parameters
 
 
   subsection Linear solver parameters - Correction step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 1000
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -46,9 +46,9 @@ subsection Navier-Stokes solver parameters
   end
 
   subsection Linear solver parameters - Diffusion step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 1000
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -62,9 +62,9 @@ subsection Navier-Stokes solver parameters
   end
 
   subsection Linear solver parameters - Poisson pre-step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 1000
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -78,9 +78,9 @@ subsection Navier-Stokes solver parameters
   end
 
   subsection Linear solver parameters - Projection step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 1000
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters

--- a/applications/DFG.prm
+++ b/applications/DFG.prm
@@ -22,9 +22,9 @@ subsection Navier-Stokes solver parameters
 
 
   subsection Linear solver parameters - Correction step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 60
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -38,9 +38,9 @@ subsection Navier-Stokes solver parameters
   end
 
   subsection Linear solver parameters - Diffusion step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 60
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -54,9 +54,9 @@ subsection Navier-Stokes solver parameters
   end
 
   subsection Linear solver parameters - Poisson pre-step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 100
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -70,9 +70,9 @@ subsection Navier-Stokes solver parameters
   end
 
   subsection Linear solver parameters - Projection step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 100
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -90,7 +90,7 @@ end
 
 subsection Output control parameters
   set Graphical output directory = DFGResults/
-  set Graphical output frequency = 100
+  set Graphical output frequency = 10
   set Terminal output frequency  = 1
 end
 

--- a/applications/Guermond.cc
+++ b/applications/Guermond.cc
@@ -364,10 +364,6 @@ void Guermond<dim>::solve(const unsigned int &level)
     // Compute CFL number
     cfl_number = navier_stokes.get_cfl_number();
 
-    // Updates the time step, i.e sets the value of t^{k}
-    time_stepping.set_desired_next_step_size(
-      this->compute_next_time_step(time_stepping, cfl_number));
-
     // Updates the coefficients to their k-th value
     time_stepping.update_coefficients();
 
@@ -454,7 +450,6 @@ void Guermond<dim>::run()
       double time_step = parameters.time_discretization_parameters.initial_time_step *
                          pow(parameters.convergence_test_parameters.step_size_reduction_factor,
                              cycle);
-
       *this->pcout  << std::setprecision(1)
                     << "Solving until t = "
                     << std::fixed << time_stepping.get_end_time()

--- a/applications/Guermond.prm
+++ b/applications/Guermond.prm
@@ -30,9 +30,9 @@ subsection Navier-Stokes solver parameters
 
 
   subsection Linear solver parameters - Correction step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 1000
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -46,9 +46,9 @@ subsection Navier-Stokes solver parameters
   end
 
   subsection Linear solver parameters - Diffusion step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 1000
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -62,9 +62,9 @@ subsection Navier-Stokes solver parameters
   end
 
   subsection Linear solver parameters - Poisson pre-step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 1000
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -78,9 +78,9 @@ subsection Navier-Stokes solver parameters
   end
 
   subsection Linear solver parameters - Projection step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 1000
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -98,7 +98,7 @@ end
 
 subsection Output control parameters
   set Graphical output directory = GuermondResults/
-  set Graphical output frequency = 1000
+  set Graphical output frequency = 10000
   set Terminal output frequency  = 1
 end
 

--- a/applications/GuermondNeumannBC.cc
+++ b/applications/GuermondNeumannBC.cc
@@ -391,10 +391,6 @@ void Guermond<dim>::solve(const unsigned int &level)
     // Compute CFL number
     cfl_number = navier_stokes.get_cfl_number();
 
-    // Updates the time step, i.e sets the value of t^{k}
-    time_stepping.set_desired_next_step_size(
-      this->compute_next_time_step(time_stepping, cfl_number));
-
     // Updates the coefficients to their k-th value
     time_stepping.update_coefficients();
 

--- a/applications/GuermondNeumannBC.prm
+++ b/applications/GuermondNeumannBC.prm
@@ -10,7 +10,6 @@ set Verbose                                         = false
 
 subsection Convergence test parameters
   set Convergence test type                 = temporal
-  set Number of initial global refinements  = 5
   set Number of spatial convergence cycles  = 2
   set Number of temporal convergence cycles = 7
   set Time-step reduction factor            = 0.5

--- a/applications/GuermondNeumannBC.prm
+++ b/applications/GuermondNeumannBC.prm
@@ -10,6 +10,7 @@ set Verbose                                         = false
 
 subsection Convergence test parameters
   set Convergence test type                 = temporal
+  set Number of initial global refinements  = 5
   set Number of spatial convergence cycles  = 2
   set Number of temporal convergence cycles = 2
   set Time-step reduction factor            = 0.5
@@ -30,9 +31,9 @@ subsection Navier-Stokes solver parameters
 
 
   subsection Linear solver parameters - Correction step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 1000
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -46,9 +47,9 @@ subsection Navier-Stokes solver parameters
   end
 
   subsection Linear solver parameters - Diffusion step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 1000
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -62,9 +63,9 @@ subsection Navier-Stokes solver parameters
   end
 
   subsection Linear solver parameters - Poisson pre-step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 1000
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -78,9 +79,9 @@ subsection Navier-Stokes solver parameters
   end
 
   subsection Linear solver parameters - Projection step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 1000
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -98,15 +99,8 @@ end
 
 subsection Output control parameters
   set Graphical output directory = GuermondNeumannBCResults/
-  set Graphical output frequency = 1
+  set Graphical output frequency = 10000
   set Terminal output frequency  = 1
-end
-
-
-subsection Refinement control parameters
-  set Adaptive mesh refinement               = false
-  set Maximum number of levels               = 10
-  set Number of initial global refinements   = 5
 end
 
 

--- a/applications/MIT.prm
+++ b/applications/MIT.prm
@@ -23,9 +23,9 @@ subsection Heat equation solver parameters
 
 
   subsection Linear solver parameters
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 1000
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -50,9 +50,9 @@ subsection Navier-Stokes solver parameters
 
 
   subsection Linear solver parameters - Correction step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 1000
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -66,9 +66,9 @@ subsection Navier-Stokes solver parameters
   end
 
   subsection Linear solver parameters - Diffusion step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 1000
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -82,9 +82,9 @@ subsection Navier-Stokes solver parameters
   end
 
   subsection Linear solver parameters - Poisson pre-step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 1000
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -98,9 +98,9 @@ subsection Navier-Stokes solver parameters
   end
 
   subsection Linear solver parameters - Projection step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 1000
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -118,7 +118,7 @@ end
 
 subsection Output control parameters
   set Graphical output directory = MITResults/
-  set Graphical output frequency = 1
+  set Graphical output frequency = 5
   set Terminal output frequency  = 1
 end
 

--- a/applications/TGV.cc
+++ b/applications/TGV.cc
@@ -337,10 +337,6 @@ void TGV<dim>::solve(const unsigned int &level)
     // Compute CFL number
     cfl_number = navier_stokes.get_cfl_number();
 
-    // Updates the time step, i.e sets the value of t^{k}
-    time_stepping.set_desired_next_step_size(
-      this->compute_next_time_step(time_stepping, cfl_number));
-
     // Updates the coefficients to their k-th value
     time_stepping.update_coefficients();
 

--- a/applications/TGV.prm
+++ b/applications/TGV.prm
@@ -30,9 +30,9 @@ subsection Navier-Stokes solver parameters
 
 
   subsection Linear solver parameters - Correction step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 1000
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -46,9 +46,9 @@ subsection Navier-Stokes solver parameters
   end
 
   subsection Linear solver parameters - Diffusion step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 1000
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -62,9 +62,9 @@ subsection Navier-Stokes solver parameters
   end
 
   subsection Linear solver parameters - Poisson pre-step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 1000
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -78,9 +78,9 @@ subsection Navier-Stokes solver parameters
   end
 
   subsection Linear solver parameters - Projection step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 1000
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -98,7 +98,7 @@ end
 
 subsection Output control parameters
   set Graphical output directory = TGVResults/
-  set Graphical output frequency = 1000
+  set Graphical output frequency = 10000
   set Terminal output frequency  = 1
 end
 

--- a/applications/ThermalTGV.prm
+++ b/applications/ThermalTGV.prm
@@ -29,9 +29,9 @@ subsection Heat equation solver parameters
 
 
   subsection Linear solver parameters
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 1000
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -48,7 +48,7 @@ end
 
 subsection Output control parameters
   set Graphical output directory = ThermalTGVResults/
-  set Graphical output frequency = 100
+  set Graphical output frequency = 10000
   set Terminal output frequency  = 1
 end
 

--- a/applications/step-35.prm
+++ b/applications/step-35.prm
@@ -20,9 +20,9 @@ subsection Navier-Stokes solver parameters
 
 
   subsection Linear solver parameters - Correction step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 50
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -36,9 +36,9 @@ subsection Navier-Stokes solver parameters
   end
 
   subsection Linear solver parameters - Diffusion step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 50
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -52,9 +52,9 @@ subsection Navier-Stokes solver parameters
   end
 
   subsection Linear solver parameters - Poisson pre-step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 150
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters
@@ -68,9 +68,9 @@ subsection Navier-Stokes solver parameters
   end
 
   subsection Linear solver parameters - Projection step
-    set Absolute tolerance           = 1e-9
+    set Absolute tolerance           = 1e-11
     set Maximum number of iterations = 150
-    set Relative tolerance           = 1e-6
+    set Relative tolerance           = 1e-10
 
 
     subsection Preconditioner parameters


### PR DESCRIPTION
The positive convergence rates obtained from `Guermond.cc` and `TGV.cc` were caused by a high tolerance value. The reduced values introduced in this branch correct this.