### PR TITLE
Fixes 119

### DIFF
--- a/applications/Couette.cc
+++ b/applications/Couette.cc
@@ -393,7 +393,7 @@ void Couette<dim>::run()
 
       this->triangulation.refine_global();
 
-      navier_stokes.reset_phi();
+      navier_stokes.clear();
     }
     break;
   case ConvergenceTest::ConvergenceTestType::temporal:
@@ -418,7 +418,7 @@ void Couette<dim>::run()
 
       solve(parameters.spatial_discretization_parameters.n_initial_global_refinements);
 
-      navier_stokes.reset_phi();
+      navier_stokes.clear();
     }
     break;
   default:

--- a/applications/DFG.cc
+++ b/applications/DFG.cc
@@ -527,7 +527,7 @@ void DFG<dim>::run()
 
   time_stepping.restart();
   velocity->old_old_solution = velocity->solution;
-  navier_stokes.reset_phi();
+  navier_stokes.clear();
 
   *this->pcout << "Solving until t = "
                << time_stepping.get_end_time()

--- a/applications/Guermond.cc
+++ b/applications/Guermond.cc
@@ -120,8 +120,6 @@ pressure_convergence_table(pressure, *pressure_exact_solution),
 flag_set_exact_pressure_constant(true),
 flag_square_domain(true)
 {
-  navier_stokes.set_body_force(body_force);
-
   *this->pcout << parameters << std::endl << std::endl;
 
   log_file << "Step" << ","
@@ -340,6 +338,7 @@ void Guermond<dim>::update_entities()
 template <int dim>
 void Guermond<dim>::solve(const unsigned int &level)
 {
+  navier_stokes.set_body_force(body_force);
   setup_dofs();
   setup_constraints();
   velocity->reinit();
@@ -439,7 +438,7 @@ void Guermond<dim>::run()
 
       this->triangulation.refine_global();
 
-      navier_stokes.reset_phi();
+      navier_stokes.clear();
     }
     break;
   case ConvergenceTest::ConvergenceTestType::temporal:
@@ -463,7 +462,7 @@ void Guermond<dim>::run()
 
       solve(this->prm.spatial_discretization_parameters.n_initial_global_refinements);
 
-      navier_stokes.reset_phi();
+      navier_stokes.clear();
     }
     break;
   default:

--- a/applications/GuermondNeumannBC.cc
+++ b/applications/GuermondNeumannBC.cc
@@ -122,8 +122,6 @@ velocity_convergence_table(velocity, *velocity_exact_solution),
 pressure_convergence_table(pressure, *pressure_exact_solution),
 flag_set_exact_pressure_constant(false)
 {
-  navier_stokes.set_body_force(body_force);
-
   *this->pcout << parameters << std::endl << std::endl;
 
   log_file << "Step" << ","
@@ -358,6 +356,7 @@ void Guermond<dim>::update_entities()
 template <int dim>
 void Guermond<dim>::solve(const unsigned int &level)
 {
+  navier_stokes.set_body_force(body_force);
   setup_dofs();
   setup_constraints();
   velocity->reinit();
@@ -466,7 +465,7 @@ void Guermond<dim>::run()
 
       this->triangulation.refine_global();
 
-      navier_stokes.reset_phi();
+      navier_stokes.clear();
     }
     break;
   case ConvergenceTest::ConvergenceTestType::temporal:
@@ -491,7 +490,7 @@ void Guermond<dim>::run()
 
       solve(parameters.spatial_discretization_parameters.n_initial_global_refinements);
 
-      navier_stokes.reset_phi();
+      navier_stokes.clear();
     }
     break;
   default:

--- a/applications/TGV.cc
+++ b/applications/TGV.cc
@@ -416,7 +416,7 @@ void TGV<dim>::run()
 
       this->triangulation.refine_global();
 
-      navier_stokes.reset_phi();
+      navier_stokes.clear();
     }
     break;
   case ConvergenceTest::ConvergenceTestType::temporal:
@@ -441,7 +441,7 @@ void TGV<dim>::run()
 
       solve(parameters.spatial_discretization_parameters.n_initial_global_refinements);
 
-      navier_stokes.reset_phi();
+      navier_stokes.clear();
     }
     break;
   default:

--- a/source/navier_stokes_projection.cc
+++ b/source/navier_stokes_projection.cc
@@ -22,6 +22,8 @@ mpi_communicator(velocity->mpi_communicator),
 velocity(velocity),
 pressure(pressure),
 time_stepping(time_stepping),
+norm_diffusion_rhs(std::numeric_limits<double>::min()),
+norm_projection_rhs(std::numeric_limits<double>::min()),
 flag_normalize_pressure(false),
 flag_setup_phi(true),
 flag_matrices_were_updated(true)


### PR DESCRIPTION
Fixes #119 by making a `clear_boundary_conditions` call during the setup of `phi` and reintroducing a the `clear` method you wrote in #84. I'll rerun the convergence tests and post the results here.

Furthermore, I am considering deleting the `NavierStokesProjection::reset` and `NavierStokesProjection::reset_phi` [methods](https://github.com/j507/RotatingMHD/blob/e972137271d0200484e59fa8621c739a70913c84/source/navier_stokes_projection/setup.cc#L440-L468) as I don't see use for them anymore. Additionally, I would delete `Couette.cc` as it not being used and its purpose of verifying the Neumann boundary conditons is already being done by `GuermondNeumannBC.cc`. Let me know your thoughts on this.