### PR TITLE
Add maximum number of timesteps to applications

### DIFF
--- a/applications/Christensen.cc
+++ b/applications/Christensen.cc
@@ -364,12 +364,6 @@ void Christensen<dim>::postprocessing()
   // class for further information.
   christensen_benchmark.compute_benchmark_data();
 
-  // Time stepping output
-  *this->pcout << time_stepping << " ["
-               << std::setw(5)
-               << std::fixed << std::setprecision(1)
-               << time_stepping.get_current_time()/time_stepping.get_end_time() * 100.
-               << "%] \n";
   // Outputs CFL number and norms of the right-hand sides
   *this->pcout << "CFL = " << std::scientific << std::setprecision(2)
                << cfl_number
@@ -460,7 +454,10 @@ void Christensen<dim>::run()
   temperature->solution = temperature->old_solution;
   output();
 
-  while (time_stepping.get_current_time() < time_stepping.get_end_time())
+  const unsigned int n_steps = this->prm.time_discretization_parameters.n_maximum_steps;
+
+  while (time_stepping.get_current_time() < time_stepping.get_end_time() &&
+         time_stepping.get_step_number() < n_steps)
   {
     // The VSIMEXMethod instance starts each loop at t^{k-1}
 
@@ -481,6 +478,7 @@ void Christensen<dim>::run()
     // Advances the VSIMEXMethod instance to t^{k}
     update_solution_vectors();
     time_stepping.advance_time();
+    *this->pcout << time_stepping << std::endl;
 
     // Performs post-processing
     if ((time_stepping.get_step_number() %

--- a/applications/Christensen.cc
+++ b/applications/Christensen.cc
@@ -457,7 +457,7 @@ void Christensen<dim>::run()
   const unsigned int n_steps = this->prm.time_discretization_parameters.n_maximum_steps;
 
   while (time_stepping.get_current_time() < time_stepping.get_end_time() &&
-         time_stepping.get_step_number() < n_steps)
+         (n_steps > 0? time_stepping.get_step_number() < n_steps: true))
   {
     // The VSIMEXMethod instance starts each loop at t^{k-1}
 

--- a/applications/Christensen.prm
+++ b/applications/Christensen.prm
@@ -127,8 +127,8 @@ subsection Refinement control parameters
   set Maximum number of levels               = 5
   set Minimum number of levels               = 0
   set Number of initial adaptive refinements = 0
-  set Number of initial boundary refinements = 2
-  set Number of initial global refinements   = 5
+  set Number of initial boundary refinements = 0
+  set Number of initial global refinements   = 1
 end
 
 

--- a/applications/DFG.cc
+++ b/applications/DFG.cc
@@ -280,8 +280,6 @@ public:
   void run();
 private:
 
-  const RunTimeParameters::ProblemParameters   &parameters;
-
   std::shared_ptr<Entities::VectorEntity<dim>>  velocity;
 
   std::shared_ptr<Entities::ScalarEntity<dim>>  pressure;
@@ -319,7 +317,6 @@ template <int dim>
 DFG<dim>::DFG(const RunTimeParameters::ProblemParameters &parameters)
 :
 Problem<dim>(parameters),
-parameters(parameters),
 velocity(std::make_shared<Entities::VectorEntity<dim>>
          (parameters.fe_degree_velocity,
           this->triangulation,
@@ -409,7 +406,7 @@ void DFG<dim>::setup_constraints()
   velocity->boundary_conditions.set_dirichlet_bcs
   (0,
    std::make_shared<EquationData::DFG::VelocityInflowBoundaryCondition<dim>>(
-     parameters.time_discretization_parameters.start_time));
+     this->prm.time_discretization_parameters.start_time));
 
   velocity->boundary_conditions.set_dirichlet_bcs(2);
   velocity->boundary_conditions.set_dirichlet_bcs(3);
@@ -443,8 +440,8 @@ void DFG<dim>::postprocessing()
 
   benchmark_request.compute_pressure_difference(pressure);
   benchmark_request.compute_drag_and_lift_coefficients(velocity,
-                                                        pressure);
-  benchmark_request.print_step_data(time_stepping);
+                                                       pressure);
+  benchmark_request.print_step_data();
   benchmark_request.update_table(time_stepping);
 }
 
@@ -492,9 +489,13 @@ void DFG<dim>::update_solution_vectors()
 template <int dim>
 void DFG<dim>::run()
 {
+  const unsigned int n_steps = this->prm.time_discretization_parameters.n_maximum_steps;
+
   *this->pcout << "Solving until t = 350..." << std::endl;
 
-  while (time_stepping.get_current_time() <= 350.0)
+  *this->pcout << time_stepping << std::endl;
+  while (time_stepping.get_current_time() <= 350.0 &&
+         time_stepping.get_step_number() < n_steps)
   {
     // The VSIMEXMethod instance starts each loop at t^{k-1}
 
@@ -514,6 +515,7 @@ void DFG<dim>::run()
     // Advances the VSIMEXMethod instance to t^{k}
     update_solution_vectors();
     time_stepping.advance_time();
+    *this->pcout << time_stepping << std::endl;
 
     // Snapshot stage, all time calls should be done with get_current_time()
     if ((time_stepping.get_step_number() %
@@ -522,10 +524,11 @@ void DFG<dim>::run()
           time_stepping.get_end_time()))
       postprocessing();
   }
+  const unsigned int n_remaining_steps{n_steps - time_stepping.get_step_number()};
 
   *this->pcout << "Restarting..." << std::endl;
-
   time_stepping.restart();
+
   velocity->old_old_solution = velocity->solution;
   navier_stokes.clear();
 
@@ -533,7 +536,10 @@ void DFG<dim>::run()
                << time_stepping.get_end_time()
                << "..." << std::endl;
 
-  while (time_stepping.get_current_time() < time_stepping.get_end_time())
+  *this->pcout << time_stepping << std::endl;
+
+  while (time_stepping.get_current_time() < time_stepping.get_end_time() &&
+         time_stepping.get_step_number() < n_remaining_steps)
   {
     // The VSIMEXMethod instance starts each loop at t^{k-1}
 
@@ -553,6 +559,7 @@ void DFG<dim>::run()
     // Advances the VSIMEXMethod instance to t^{k}
     update_solution_vectors();
     time_stepping.advance_time();
+    *this->pcout << time_stepping << std::endl;
 
     // Snapshot stage, all time calls should be done with get_current_time()
     if ((time_stepping.get_step_number() %

--- a/applications/DFG.cc
+++ b/applications/DFG.cc
@@ -495,7 +495,7 @@ void DFG<dim>::run()
 
   *this->pcout << time_stepping << std::endl;
   while (time_stepping.get_current_time() <= 350.0 &&
-         time_stepping.get_step_number() < n_steps)
+         (n_steps > 0? time_stepping.get_step_number() < n_steps: true))
   {
     // The VSIMEXMethod instance starts each loop at t^{k-1}
 

--- a/applications/DFG.prm
+++ b/applications/DFG.prm
@@ -18,7 +18,7 @@ subsection Navier-Stokes solver parameters
   set Convective term weak form              = skew-symmetric
   set Incremental pressure-correction scheme = rotational
   set Preconditioner update frequency        = 15
-  set Verbose                                = true
+  set Verbose                                = false
 
 
   subsection Linear solver parameters - Correction step

--- a/applications/MIT.cc
+++ b/applications/MIT.cc
@@ -417,7 +417,7 @@ void MITBenchmark<dim>::run()
 
   *this->pcout << time_stepping << std::endl;
   while (time_stepping.get_current_time() < time_stepping.get_end_time() &&
-         time_stepping.get_step_number() < n_steps)
+         (n_steps > 0? time_stepping.get_step_number() < n_steps: true))
   {
     // The VSIMEXMethod instance starts each loop at t^{k-1}
 

--- a/applications/MIT.cc
+++ b/applications/MIT.cc
@@ -338,12 +338,11 @@ void MITBenchmark<dim>::postprocessing()
   // class for further information.
   mit_benchmark.compute_benchmark_data();
 
-  std::cout.precision(1);
   /*! @attention For some reason, a run time error happens when I try
       to only use one pcout */
-  *this->pcout << time_stepping << ", ";
-  *this->pcout << mit_benchmark
-               << ", CFL = "
+  *this->pcout << "    ";
+  *this->pcout << mit_benchmark << std::endl;
+  *this->pcout << "    CFL = "
                << cfl_number
                << ", Norms: ("
                << std::noshowpos << std::scientific
@@ -352,11 +351,8 @@ void MITBenchmark<dim>::postprocessing()
                << navier_stokes.get_projection_step_rhs_norm()
                << ", "
                << heat_equation.get_rhs_norm()
-               << ") ["
-               << std::setw(5)
-               << std::fixed
-               << time_stepping.get_next_time()/time_stepping.get_end_time() * 100.
-               << "%] \r";
+               << ")"
+               << std::endl;
 
   if (time_stepping.get_step_number() % 10 == 0)
     cfl_output_file << time_stepping.get_current_time() << ","
@@ -417,7 +413,11 @@ void MITBenchmark<dim>::update_solution_vectors()
 template <int dim>
 void MITBenchmark<dim>::run()
 {
-  while (time_stepping.get_current_time() < time_stepping.get_end_time())
+  const unsigned int n_steps = this->prm.time_discretization_parameters.n_maximum_steps;
+
+  *this->pcout << time_stepping << std::endl;
+  while (time_stepping.get_current_time() < time_stepping.get_end_time() &&
+         time_stepping.get_step_number() < n_steps)
   {
     // The VSIMEXMethod instance starts each loop at t^{k-1}
 
@@ -442,6 +442,7 @@ void MITBenchmark<dim>::run()
     // Advances the VSIMEXMethod instance to t^{k}
     update_solution_vectors();
     time_stepping.advance_time();
+    *this->pcout << time_stepping << std::endl;
 
     // Performs post-processing
     postprocessing();

--- a/applications/step-35.cc
+++ b/applications/step-35.cc
@@ -68,8 +68,6 @@ private:
   void output();
 
   void update_solution_vectors();
-
-  void sample_point_data(const Point<dim> &point) const;
 };
 
 template <int dim>
@@ -196,7 +194,32 @@ void Step35<dim>::postprocessing()
 {
   TimerOutput::Scope  t(*this->computing_timer, "Problem: Postprocessing");
 
-  sample_point_data(evaluation_point);
+  const std::pair<typename DoFHandler<dim>::active_cell_iterator,Point<dim>>
+  cell_point =
+  GridTools::find_active_cell_around_point(StaticMappingQ1<dim, dim>::mapping,
+                                           *velocity->dof_handler,
+                                           evaluation_point);
+  if (cell_point.first->is_locally_owned())
+  {
+    Vector<double> point_value_velocity(dim);
+    VectorTools::point_value(*velocity->dof_handler,
+                             velocity->solution,
+                             evaluation_point,
+                             point_value_velocity);
+
+    const double point_value_pressure
+    = VectorTools::point_value(*pressure->dof_handler,
+                               pressure->solution,
+                               evaluation_point);
+
+    *this->pcout << "   Velocity = ("
+                 << std::showpos << std::scientific
+                 << point_value_velocity[0]
+                 << ", "
+                 << point_value_velocity[1]
+                 << ") Pressure = "
+                 << point_value_pressure  << std::noshowpos << std::endl;
+  }
 }
 
 template <int dim>
@@ -240,7 +263,12 @@ void Step35<dim>::update_solution_vectors()
 template <int dim>
 void Step35<dim>::run()
 {
-  while (time_stepping.get_current_time() < time_stepping.get_end_time())
+  const unsigned int n_steps = this->parameters.time_discretization_parameters.n_maximum_steps;
+
+  *this->pcout << time_stepping << std::endl;
+
+  while (time_stepping.get_current_time() < time_stepping.get_end_time() &&
+         time_stepping.get_step_number() < n_steps)
   {
     // The VSIMEXMethod instance starts each loop at t^{k-1}
 
@@ -248,8 +276,7 @@ void Step35<dim>::run()
     cfl_number = navier_stokes.get_cfl_number();
 
     // Updates the time step, i.e sets the value of t^{k}
-    time_stepping.set_desired_next_step_size(
-      this->compute_next_time_step(time_stepping, cfl_number));
+    time_stepping.set_desired_next_step_size(this->compute_next_time_step(time_stepping, cfl_number));
 
     // Updates the coefficients to their k-th value
     time_stepping.update_coefficients();
@@ -260,6 +287,7 @@ void Step35<dim>::run()
     // Advances the VSIMEXMethod instance to t^{k}
     update_solution_vectors();
     time_stepping.advance_time();
+    *this->pcout << time_stepping << std::endl;
 
     // Snapshot stage
     if (time_stepping.get_step_number() %
@@ -282,37 +310,6 @@ void Step35<dim>::run()
 
 }
 
-template <int dim>
-void Step35<dim>::sample_point_data(const Point<dim> &point) const
-{
-  const std::pair<typename DoFHandler<dim>::active_cell_iterator,Point<dim>>
-  cell_point =
-  GridTools::find_active_cell_around_point(StaticMappingQ1<dim, dim>::mapping,
-                                           *velocity->dof_handler,
-                                           point);
-  if (cell_point.first->is_locally_owned())
-  {
-    Vector<double> point_value_velocity(dim);
-    VectorTools::point_value(*velocity->dof_handler,
-                            velocity->solution,
-                            point,
-                            point_value_velocity);
-
-    const double point_value_pressure
-    = VectorTools::point_value(*pressure->dof_handler,
-                              pressure->solution,
-                              point);
-
-    std::cout << time_stepping
-              << " Velocity = ("
-              << std::showpos << std::scientific
-              << point_value_velocity[0]
-              << ", "
-              << point_value_velocity[1]
-              << ") Pressure = "
-              << point_value_pressure  << std::noshowpos << std::endl;
-  }
-}
 } // namespace RMHD
 
 int main(int argc, char *argv[])

--- a/applications/step-35.cc
+++ b/applications/step-35.cc
@@ -268,7 +268,7 @@ void Step35<dim>::run()
   *this->pcout << time_stepping << std::endl;
 
   while (time_stepping.get_current_time() < time_stepping.get_end_time() &&
-         time_stepping.get_step_number() < n_steps)
+         (n_steps > 0? time_stepping.get_step_number() < n_steps: true))
   {
     // The VSIMEXMethod instance starts each loop at t^{k-1}
 

--- a/include/rotatingMHD/benchmark_data.h
+++ b/include/rotatingMHD/benchmark_data.h
@@ -190,18 +190,13 @@ struct DFGBechmarkRequest
    * the current dimensionless time, @ref pressure_difference,
    * @ref drag_coefficient and the @ref lift_coefficient.
    */
-  void print_step_data(TimeDiscretization::DiscreteTime &time);
+  void print_step_data();
 
   /*!
    * @brief A method that outputs the @ref data_table into a file.
    */
   void write_table_to_file(const std::string &file);
 };
-
-template<int dim> class MIT;
-
-template<typename Stream, int dim>
-Stream& operator<<(Stream &, const MIT<dim> &);
 
 /*!
  * @class MIT
@@ -249,7 +244,7 @@ public:
    * @brief Output of the benchmark data to the terminal.
    */
   template<typename Stream, int dim_>
-  friend Stream& operator<<(Stream &stream, const MIT<dim_> &mit);
+  friend Stream& operator<<(Stream &, const MIT<dim_> &);
 
 private:
   /*!
@@ -453,10 +448,11 @@ private:
 
 
 
-template<int dim> class ChristensenBenchmark;
-
 template<typename Stream, int dim>
-Stream& operator<<(Stream &, const ChristensenBenchmark<dim> &);
+Stream& operator<<(Stream &, const MIT<dim> &);
+
+
+
 
 /*!
  * @class ChristensenBenchmark
@@ -505,7 +501,7 @@ public:
    * @brief Output of the benchmark data to the terminal.
    */
   template<typename Stream, int dim_>
-  friend Stream& operator<<(Stream &stream, const ChristensenBenchmark<dim_> &mit);
+  friend Stream& operator<<(Stream &, const ChristensenBenchmark<dim_> &);
 
 
 private:
@@ -716,6 +712,9 @@ private:
    */
   void compute_point_data();
 };
+
+template<typename Stream, int dim>
+Stream& operator<<(Stream &, const ChristensenBenchmark<dim> &);
 
 } // namespace BenchmarkData
 

--- a/source/benchmark_data.cc
+++ b/source/benchmark_data.cc
@@ -184,20 +184,14 @@ void DFGBechmarkRequest<dim>::update_table(TimeDiscretization::DiscreteTime  &ti
 }
 
 template <int dim>
-void DFGBechmarkRequest<dim>::print_step_data(TimeDiscretization::DiscreteTime &time)
+void DFGBechmarkRequest<dim>::print_step_data()
 {
   ConditionalOStream  pcout(std::cout,
                             (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0));
 
-  pcout << "Step = "
-        << std::setw(4)
-        << time.get_step_number()
-        << " Time = "
-        << std::noshowpos << std::scientific
-        << time.get_current_time()
-        << " dp = "
+  pcout << "    dp = "
         << std::setprecision(6)
-	<< std::showpos << std::scientific
+	      << std::showpos << std::scientific
         << pressure_difference
         << " C_d = "
         << std::showpos << std::scientific
@@ -205,7 +199,7 @@ void DFGBechmarkRequest<dim>::print_step_data(TimeDiscretization::DiscreteTime &
         << " C_l = "
         << std::showpos << std::scientific
         << lift_coefficient
-	<< std::defaultfloat << std::endl;
+        << std::defaultfloat << std::endl;
 }
 
 template <int dim>


### PR DESCRIPTION
Changes:

- terminal printing
- remove unnecessary method in application `step-35.cc`
- make all applications run 10 time steps by default
- reduce refinement in `Christensen.cc`