### PR TITLE
Overhaul of ProjectionSolverBase<dim>

### DIFF
--- a/include/rotatingMHD/assembly_data.h
+++ b/include/rotatingMHD/assembly_data.h
@@ -103,6 +103,73 @@ struct Scratch : ScratchBase<dim>
 
 } // namespace Generic
 
+
+
+namespace ProjectionSolverBase
+{
+
+
+
+namespace VectorFieldConstantMatrices
+{
+
+
+
+using Copy = Generic::Matrix::MassStiffnessCopy;
+
+template <int dim>
+struct Scratch : Generic::Matrix::Scratch<dim>
+{
+  Scratch(const Mapping<dim>        &mapping,
+          const Quadrature<dim>     &quadrature_formula,
+          const FiniteElement<dim>  &fe,
+          const UpdateFlags         update_flags);
+
+  Scratch(const Scratch<dim>    &data);
+
+  std::vector<Tensor<1, dim>> phi;
+
+  std::vector<Tensor<2, dim>> grad_phi;
+};
+
+
+
+} // namespace VectorFieldConstantMatrices
+
+
+
+namespace ScalarFieldsConstantMatrices
+{
+
+
+
+
+using Copy = Generic::Matrix::MassStiffnessCopy;
+
+template <int dim>
+struct Scratch : Generic::Matrix::Scratch<dim>
+{
+  Scratch(const Mapping<dim>        &mapping,
+          const Quadrature<dim>     &quadrature_formula,
+          const FiniteElement<dim>  &fe,
+          const UpdateFlags         update_flags);
+
+  Scratch(const Scratch<dim>        &data);
+
+  std::vector<double>         phi;
+
+  std::vector<Tensor<1, dim>> grad_phi;
+};
+
+
+
+} // namespace ScalarFieldsConstantMatrices
+
+
+
+} // namespace ProjectionSolverBase
+
+
 namespace NavierStokesProjection
 {
 

--- a/include/rotatingMHD/run_time_parameters.h
+++ b/include/rotatingMHD/run_time_parameters.h
@@ -314,6 +314,112 @@ Stream& operator<<(Stream &stream, const DimensionlessNumbers &prm);
 
 
 /*!
+ * @brief A base clase for the parameters of solvers, which are based
+ * on projection schemes.
+ *
+ */
+struct ProjectionSolverParametersBase
+{
+  /*!
+   * Constructor which sets up the parameters with default values.
+   */
+  ProjectionSolverParametersBase();
+
+  /*!
+   * @brief Constructor which sets up the parameters as specified in the
+   * parameter file with the filename @p parameter_filename.
+   */
+  ProjectionSolverParametersBase(const std::string &parameter_filename);
+
+  /*!
+   * @brief Static method which declares the associated parameter to the
+   * ParameterHandler object @p prm.
+   */
+  static void declare_parameters(ParameterHandler &prm);
+
+  /*!
+   * @brief Method which parses the parameters from the ParameterHandler
+   * object @p prm.
+   */
+  void parse_parameters(ParameterHandler &prm);
+
+  /*!
+   * @brief Method forwarding parameters to a stream object.
+   *
+   * @details This method does not add a `std::endl` to the stream at the end.
+   *
+   */
+  template<typename Stream>
+  friend Stream& operator<<(Stream &stream, const ProjectionSolverParametersBase &prm);
+
+  /*!
+   * @brief Enumerator controlling the incremental pressure-correction
+   * scheme is to be implemented.
+   */
+  PressureCorrectionScheme          pressure_correction_scheme;
+
+  /*!
+   * @brief Enumerator controlling which weak form of the convective
+   * term is to be implemented
+   */
+  ConvectiveTermWeakForm            convective_term_weak_form;
+
+  /*!
+   * @brief Enumerator controlling which time discretization of the
+   * convective term is to be implemented
+   */
+  ConvectiveTermTimeDiscretization  convective_term_time_discretization;
+
+  /*!
+   * @brief The parameters for the linear solver used in the
+   * diffusion step.
+   */
+  LinearSolverParameters            diffusion_step_solver_parameters;
+
+  /*!
+   * @brief The parameters for the linear solver used in the
+   * diffusion step.
+   */
+  LinearSolverParameters            projection_step_solver_parameters;
+
+  /*!
+   * @brief The parameters for the linear solver used in the
+   * diffusion step.
+   */
+  LinearSolverParameters            correction_step_solver_parameters;
+
+  /*!
+   * @brief The parameters for the linear solver used in the
+   * poisson pre-step.
+   */
+  LinearSolverParameters            zeroth_step_solver_parameters;
+
+  /*!
+   * @brief Specifies the frequency of the update of the diffusion
+   * preconditioner.
+   */
+  unsigned int                      preconditioner_update_frequency;
+
+  /*!
+   * @brief Boolean flag to enable verbose output on the terminal.
+   */
+  bool                              verbose;
+};
+
+
+
+/*!
+ * @brief Method forwarding parameters to a stream object.
+ *
+ * @details This method does not add a `std::endl` to the stream at the end.
+ *
+ */
+template<typename Stream>
+Stream& operator<<(Stream &stream, const ProjectionSolverParametersBase &prm);
+
+
+
+/*!
  * @struct NavierStokesParameters
  *
  * @brief A structure containing all the parameters of the Navier-Stokes

--- a/include/rotatingMHD/run_time_parameters.h
+++ b/include/rotatingMHD/run_time_parameters.h
@@ -353,12 +353,6 @@ struct ProjectionSolverParametersBase
   friend Stream& operator<<(Stream &stream, const ProjectionSolverParametersBase &prm);
 
   /*!
-   * @brief Enumerator controlling the incremental pressure-correction
-   * scheme is to be implemented.
-   */
-  PressureCorrectionScheme          pressure_correction_scheme;
-
-  /*!
    * @brief Enumerator controlling which weak form of the convective
    * term is to be implemented
    */

--- a/include/rotatingMHD/solver_class.h
+++ b/include/rotatingMHD/solver_class.h
@@ -1,6 +1,7 @@
 #ifndef INCLUDE_ROTATINGMHD_SOLVER_CLASS_H_
 #define INCLUDE_ROTATINGMHD_SOLVER_CLASS_H_
 
+#include <rotatingMHD/assembly_data.h>
 #include <rotatingMHD/finite_element_field.h>
 #include <rotatingMHD/global.h>
 #include <rotatingMHD/run_time_parameters.h>
@@ -573,14 +574,66 @@ virtual void assemble_constant_matrices() override;
  * matrices from vector valued variables.
  *
  */
-virtual void assemble_constant_matrices_vector_field() = 0;
+virtual void assemble_constant_matrices_vector_field();
 
 /*!
- * @brief A pure virtual method for the assembly of all constant
+ * @brief A virtual method for the element-wise assembly of the
+ * mass and stiffness matrices of vector-valued variables.
+ *
+ * @param cell The deal.ii entity, which manages the cell iteration.
+ * @param scratch The copy structure for the assembly of the mass and
+ * stiffness matrices of vector-valued finite elements.
+ * @param data The copy structure for the assembly of the mass and
+ * stiffness matrices of vector-valued finite elements.
+ */
+virtual void assemble_local_matrices_vector_field(
+ const typename DoFHandler<dim>::active_cell_iterator  &cell,
+ AssemblyData::ProjectionSolverBase::VectorFieldConstantMatrices::Scratch<dim> &scratch,
+ AssemblyData::ProjectionSolverBase::VectorFieldConstantMatrices::Copy &data);
+
+/*!
+ * @brief A virtual method for the mapping of local mass and stiffness
+ * matrices to the global mass and stiffness matrices of vector-valued
+ * finite elements.
+ *
+ * @param data The copy structure for the assembly of the mass and
+ * stiffness matrices of vector-valued finite elements.
+ */
+virtual void copy_local_to_global_matrices_vector_field(
+ const AssemblyData::ProjectionSolverBase::VectorFieldConstantMatrices::Copy &data);
+
+/*!
+ * @brief A virtual method for the assembly of all constant
  * matrices from scalar valued variables.
  *
  */
-virtual void assemble_constant_matrices_scalar_fields() = 0;
+virtual void assemble_constant_matrices_scalar_fields();
+
+/*!
+ * @brief A virtual method for the element-wise assembly of the
+ * mass and stiffness matrices of scalar-valued variables.
+ *
+ * @param cell The deal.ii entity, which manages the cell iteration.
+ * @param scratch The scratch structure for the assembly of the mass and
+ * stiffness matrices of scalar-valued finite elements
+ * @param data The copy structure for the assembly of the mass and
+ * stiffness matrices of scalar-valued finite elements
+ */
+virtual void assemble_local_matrices_scalar_fields(
+ const typename DoFHandler<dim>::active_cell_iterator  &cell,
+ AssemblyData::ProjectionSolverBase::ScalarFieldsConstantMatrices::Scratch<dim> &scratch,
+ AssemblyData::ProjectionSolverBase::ScalarFieldsConstantMatrices::Copy &data);
+
+/*!
+ * @brief A virtual method for the mapping of local mass and stiffness
+ * matrices to the global mass and stiffness matrices of scalar-valued
+ * finite elements.
+ *
+ * @param data The copy structure for the assembly of the mass and
+ * stiffness matrices of scalar-valued finite elements.
+ */
+virtual void copy_local_to_global_matrices_scalar_fields(
+ const AssemblyData::ProjectionSolverBase::ScalarFieldsConstantMatrices::Copy &data);
 
 /*!
  * @brief A pure virtual method assembling the right-hand side vector

--- a/source/assembly_data.cc
+++ b/source/assembly_data.cc
@@ -111,6 +111,86 @@ fe_values(data.fe_values.get_mapping(),
 
 } // namespace Generic
 
+
+
+namespace ProjectionSolverBase
+{
+
+
+
+namespace VectorFieldConstantMatrices
+{
+
+
+
+template <int dim>
+Scratch<dim>::Scratch(
+  const Mapping<dim>        &mapping,
+  const Quadrature<dim>     &quadrature_formula,
+  const FiniteElement<dim>  &fe,
+  const UpdateFlags         update_flags)
+:
+Generic::Matrix::Scratch<dim>(mapping,
+                              quadrature_formula,
+                              fe,
+                              update_flags),
+phi(this->dofs_per_cell),
+grad_phi(this->dofs_per_cell)
+{}
+
+
+
+template <int dim>
+Scratch<dim>::Scratch(const Scratch<dim> &data)
+:
+Generic::Matrix::Scratch<dim>(data),
+phi(data.dofs_per_cell),
+grad_phi(data.dofs_per_cell)
+{}
+
+
+
+} // namespace VectorFieldConstantMatrices
+
+
+
+namespace ScalarFieldsConstantMatrices
+{
+
+
+
+template <int dim>
+Scratch<dim>::Scratch(
+  const Mapping<dim>        &mapping,
+  const Quadrature<dim>     &quadrature_formula,
+  const FiniteElement<dim>  &fe,
+  const UpdateFlags         update_flags)
+:
+Generic::Matrix::Scratch<dim>(mapping,
+                              quadrature_formula,
+                              fe,
+                              update_flags),
+phi(this->dofs_per_cell),
+grad_phi(this->dofs_per_cell)
+{}
+
+
+
+template <int dim>
+Scratch<dim>::Scratch(const Scratch<dim> &data)
+:
+Generic::Matrix::Scratch<dim>(data),
+phi(data.dofs_per_cell),
+grad_phi(data.dofs_per_cell)
+{}
+
+
+
+} // namespace ScalarFieldsConstantMatrices
+
+
+} // namespace ProjectionSolverBase
+
 } // namespace AssemblyData
 
 } // namespace RMHD
@@ -123,3 +203,10 @@ template struct RMHD::AssemblyData::Generic::Matrix::Scratch<3>;
 
 template struct RMHD::AssemblyData::Generic::RightHandSide::Scratch<2>;
 template struct RMHD::AssemblyData::Generic::RightHandSide::Scratch<3>;
+
+template struct RMHD::AssemblyData::ProjectionSolverBase::VectorFieldConstantMatrices::Scratch<2>;
+template struct RMHD::AssemblyData::ProjectionSolverBase::VectorFieldConstantMatrices::Scratch<3>;
+
+template struct RMHD::AssemblyData::ProjectionSolverBase::ScalarFieldsConstantMatrices::Scratch<2>;
+template struct RMHD::AssemblyData::ProjectionSolverBase::ScalarFieldsConstantMatrices::Scratch<3>;
+

--- a/source/run_time_parameters.cc
+++ b/source/run_time_parameters.cc
@@ -511,7 +511,6 @@ Stream& operator<<(Stream &stream, const DimensionlessNumbers &prm)
 
 ProjectionSolverParametersBase::ProjectionSolverParametersBase()
 :
-pressure_correction_scheme(PressureCorrectionScheme::rotational),
 convective_term_weak_form(ConvectiveTermWeakForm::skewsymmetric),
 convective_term_time_discretization(ConvectiveTermTimeDiscretization::semi_implicit),
 diffusion_step_solver_parameters("Diffusion step"),

--- a/source/run_time_parameters.cc
+++ b/source/run_time_parameters.cc
@@ -509,6 +509,223 @@ Stream& operator<<(Stream &stream, const DimensionlessNumbers &prm)
 
 
 
+ProjectionSolverParametersBase::ProjectionSolverParametersBase()
+:
+pressure_correction_scheme(PressureCorrectionScheme::rotational),
+convective_term_weak_form(ConvectiveTermWeakForm::skewsymmetric),
+convective_term_time_discretization(ConvectiveTermTimeDiscretization::semi_implicit),
+diffusion_step_solver_parameters("Diffusion step"),
+projection_step_solver_parameters("Projection step"),
+correction_step_solver_parameters("Correction step"),
+zeroth_step_solver_parameters("Zeroth step"),
+preconditioner_update_frequency(10),
+verbose(false)
+{}
+
+
+
+ProjectionSolverParametersBase::ProjectionSolverParametersBase
+(const std::string &parameter_filename)
+:
+ProjectionSolverParametersBase()
+{
+  ParameterHandler prm;
+  declare_parameters(prm);
+
+  std::ifstream parameter_file(parameter_filename.c_str());
+
+  if (!parameter_file)
+  {
+    parameter_file.close();
+
+    std::ostringstream message;
+    message << "Input parameter file <"
+            << parameter_filename << "> not found. Creating a"
+            << std::endl
+            << "template file of the same name."
+            << std::endl;
+
+    std::ofstream parameter_out(parameter_filename.c_str());
+    prm.print_parameters(parameter_out,
+                         ParameterHandler::OutputStyle::Text);
+
+    AssertThrow(false, ExcMessage(message.str().c_str()));
+  }
+
+  prm.parse_input(parameter_file);
+
+  parse_parameters(prm);
+}
+
+
+
+void ProjectionSolverParametersBase::declare_parameters(ParameterHandler &prm)
+{
+  prm.declare_entry("Convective term weak form",
+                    "skew-symmetric",
+                    Patterns::Selection("standard|skew-symmetric|divergence|rotational"));
+
+  prm.declare_entry("Convective term time discretization",
+                    "semi-implicit",
+                    Patterns::Selection("semi-implicit|explicit"));
+
+  prm.declare_entry("Preconditioner update frequency",
+                    "10",
+                    Patterns::Integer(1));
+
+  prm.declare_entry("Verbose",
+                    "false",
+                    Patterns::Bool());
+
+  prm.enter_subsection("Linear solver parameters - Diffusion step");
+  {
+    LinearSolverParameters::declare_parameters(prm);
+  }
+  prm.leave_subsection();
+
+  prm.enter_subsection("Linear solver parameters - Projection step");
+  {
+    LinearSolverParameters::declare_parameters(prm);
+  }
+  prm.leave_subsection();
+
+  prm.enter_subsection("Linear solver parameters - Correction step");
+  {
+    LinearSolverParameters::declare_parameters(prm);
+  }
+  prm.leave_subsection();
+
+  prm.enter_subsection("Linear solver parameters - Zeroth step");
+  {
+    LinearSolverParameters::declare_parameters(prm);
+  }
+  prm.leave_subsection();
+}
+
+
+
+void ProjectionSolverParametersBase::parse_parameters(ParameterHandler &prm)
+{
+  const std::string str_convective_term_weak_form(prm.get("Convective term weak form"));
+
+  if (str_convective_term_weak_form == std::string("standard"))
+    convective_term_weak_form = ConvectiveTermWeakForm::standard;
+  else if (str_convective_term_weak_form == std::string("skew-symmetric"))
+    convective_term_weak_form = ConvectiveTermWeakForm::skewsymmetric;
+  else if (str_convective_term_weak_form == std::string("divergence"))
+    convective_term_weak_form = ConvectiveTermWeakForm::divergence;
+  else if (str_convective_term_weak_form == std::string("rotational"))
+    convective_term_weak_form = ConvectiveTermWeakForm::rotational;
+  else
+    AssertThrow(false,
+                ExcMessage("Unexpected identifier for the weak form "
+                            "of the convective term."));
+
+  const std::string str_convective_term_time_discretization(prm.get("Convective term time discretization"));
+
+  if (str_convective_term_time_discretization == std::string("semi-implicit"))
+    convective_term_time_discretization = ConvectiveTermTimeDiscretization::semi_implicit;
+  else if (str_convective_term_time_discretization == std::string("explicit"))
+    convective_term_time_discretization = ConvectiveTermTimeDiscretization::fully_explicit;
+  else
+    AssertThrow(false,
+                ExcMessage("Unexpected identifier for the time discretization "
+                            "of the convective term."));
+
+  preconditioner_update_frequency = prm.get_integer("Preconditioner update frequency");
+  AssertThrow(preconditioner_update_frequency > 0,
+          ExcLowerRange(preconditioner_update_frequency, 0));
+
+  verbose = prm.get_bool("Verbose");
+
+  prm.enter_subsection("Linear solver parameters - Diffusion step");
+  {
+    diffusion_step_solver_parameters.parse_parameters(prm);
+  }
+  prm.leave_subsection();
+
+  prm.enter_subsection("Linear solver parameters - Projection step");
+  {
+    projection_step_solver_parameters.parse_parameters(prm);
+  }
+  prm.leave_subsection();
+
+  prm.enter_subsection("Linear solver parameters - Correction step");
+  {
+    correction_step_solver_parameters.parse_parameters(prm);
+  }
+  prm.leave_subsection();
+
+  prm.enter_subsection("Linear solver parameters - Zeroth step");
+  {
+    zeroth_step_solver_parameters.parse_parameters(prm);
+  }
+  prm.leave_subsection();
+}
+
+
+
+template<typename Stream>
+Stream& operator<<(Stream &stream, const ProjectionSolverParametersBase &prm)
+{
+  switch (prm.convective_term_weak_form) {
+    case ConvectiveTermWeakForm::standard:
+      internal::add_line(stream, "Convective term weak form", "standard");
+      break;
+    case ConvectiveTermWeakForm::rotational:
+      internal::add_line(stream, "Convective term weak form", "rotational");
+      break;
+    case ConvectiveTermWeakForm::divergence:
+      internal::add_line(stream, "Convective term weak form", "divergence");
+      break;
+    case ConvectiveTermWeakForm::skewsymmetric:
+      internal::add_line(stream, "Convective term weak form", "skew-symmetric");
+      break;
+    default:
+      AssertThrow(false, ExcMessage("Unexpected type identifier for the "
+                               "weak form of the convective term."));
+      break;
+  }
+
+  switch (prm.convective_term_time_discretization) {
+    case ConvectiveTermTimeDiscretization::semi_implicit:
+      internal::add_line(stream, "Convective temporal form", "semi-implicit");
+      break;
+    case ConvectiveTermTimeDiscretization::fully_explicit:
+      internal::add_line(stream, "Convective temporal form", "explicit");
+      break;
+    default:
+      AssertThrow(false,
+                  ExcMessage("Unexpected type identifier for the "
+                             "time discretization of the convective term."));
+      break;
+  }
+
+  internal::add_line(stream, "Preconditioner update frequency", prm.preconditioner_update_frequency);
+
+  stream << prm.diffusion_step_solver_parameters;
+
+  stream << "\r";
+
+  stream << prm.projection_step_solver_parameters;
+
+  stream << "\r";
+
+  stream << prm.correction_step_solver_parameters;
+
+  stream << "\r";
+
+  stream << prm.zeroth_step_solver_parameters;
+
+  stream << "\r";
+
+  internal::add_header(stream);
+
+  return (stream);
+}
+
+
+
 NavierStokesParameters::NavierStokesParameters()
 :
 pressure_correction_scheme(PressureCorrectionScheme::rotational),
@@ -1713,6 +1930,11 @@ template std::ostream & RMHD::RunTimeParameters::operator<<
 (std::ostream &, const RMHD::RunTimeParameters::DimensionlessNumbers &);
 template dealii::ConditionalOStream & RMHD::RunTimeParameters::operator<<
 (dealii::ConditionalOStream &, const RMHD::RunTimeParameters::DimensionlessNumbers &);
+
+template std::ostream & RMHD::RunTimeParameters::operator<<
+(std::ostream &, const RMHD::RunTimeParameters::ProjectionSolverParametersBase &);
+template dealii::ConditionalOStream & RMHD::RunTimeParameters::operator<<
+(dealii::ConditionalOStream &, const RMHD::RunTimeParameters::ProjectionSolverParametersBase &);
 
 template std::ostream & RMHD::RunTimeParameters::operator<<
 (std::ostream &, const RMHD::RunTimeParameters::NavierStokesParameters &);

--- a/source/solver_class.cc
+++ b/source/solver_class.cc
@@ -1,7 +1,10 @@
+#include <rotatingMHD/assembly_data.h>
 #include <rotatingMHD/solver_class.h>
 #include <rotatingMHD/utility.h>
 
+#include <deal.II/base/work_stream.h>
 #include <deal.II/dofs/dof_tools.h>
+#include <deal.II/grid/filtered_iterator.h>
 #ifdef USE_PETSC_LA
   #include <deal.II/lac/dynamic_sparsity_pattern.h>
   #include <deal.II/lac/sparsity_tools.h>
@@ -482,7 +485,7 @@ std::pair<int, double> ProjectionSolverBase<dim>::solve_zeroth_step()
     std::cerr << std::endl << std::endl
               << "----------------------------------------------------"
               << std::endl;
-    std::cerr << "Exception in the solve method of the poisson pre-step: " << std::endl
+    std::cerr << "Exception in the solve method of the zeroth step: " << std::endl
               << exc.what() << std::endl
               << "Aborting!" << std::endl
               << "----------------------------------------------------"
@@ -494,7 +497,7 @@ std::pair<int, double> ProjectionSolverBase<dim>::solve_zeroth_step()
     std::cerr << std::endl << std::endl
               << "----------------------------------------------------"
                 << std::endl;
-    std::cerr << "Unknown exception in the solve method of the poisson pre-step!" << std::endl
+    std::cerr << "Unknown exception in the solve method of the  zeroth step!" << std::endl
               << "Aborting!" << std::endl
               << "----------------------------------------------------"
               << std::endl;
@@ -715,6 +718,249 @@ void ProjectionSolverBase<dim>::assemble_constant_matrices()
 }
 
 
+
+template <int dim>
+void ProjectionSolverBase<dim>::assemble_constant_matrices_vector_field()
+{
+  // Reset data
+  diffusion_step_mass_matrix      = 0.;
+  diffusion_step_stiffness_matrix = 0.;
+
+  // Initiate the quadrature formula for exact numerical integration
+  const QGauss<dim>   quadrature_formula(vector_field->fe_degree() + 1);
+
+  // Set up the lambda function for the local assembly operation
+  auto worker =
+    [this](const typename DoFHandler<dim>::active_cell_iterator &cell,
+           AssemblyData::ProjectionSolverBase::VectorFieldConstantMatrices::Scratch<dim> &scratch,
+           AssemblyData::ProjectionSolverBase::VectorFieldConstantMatrices::Copy    &data)
+    {
+      this->assemble_local_matrices_vector_field(cell,
+                                                 scratch,
+                                                 data);
+    };
+
+  // Set up the lambda function for the copy local to global operation
+  auto copier =
+    [this](const AssemblyData::ProjectionSolverBase::VectorFieldConstantMatrices::Copy &data)
+    {
+      this->copy_local_to_global_matrices_vector_field(data);
+    };
+
+  // Assemble using the WorkStream approach
+  using CellFilter =
+    FilteredIterator<typename DoFHandler<dim>::active_cell_iterator>;
+
+  WorkStream::run
+  (CellFilter(IteratorFilters::LocallyOwnedCell(),
+              vector_field->get_dof_handler().begin_active()),
+   CellFilter(IteratorFilters::LocallyOwnedCell(),
+              vector_field->get_dof_handler().end()),
+   worker,
+   copier,
+   AssemblyData::ProjectionSolverBase::VectorFieldConstantMatrices::Scratch<dim>(
+     *this->mapping,
+     quadrature_formula,
+     vector_field->get_finite_element(),
+     update_values|update_gradients|update_JxW_values),
+   AssemblyData::ProjectionSolverBase::VectorFieldConstantMatrices::Copy(
+     vector_field->get_finite_element().dofs_per_cell));
+
+  // Compress global data
+  diffusion_step_mass_matrix.compress(VectorOperation::add);
+  diffusion_step_stiffness_matrix.compress(VectorOperation::add);
+}
+
+
+
+template <int dim>
+void ProjectionSolverBase<dim>::assemble_local_matrices_vector_field(
+ const typename DoFHandler<dim>::active_cell_iterator  &cell,
+ AssemblyData::ProjectionSolverBase::VectorFieldConstantMatrices::Scratch<dim> &scratch,
+ AssemblyData::ProjectionSolverBase::VectorFieldConstantMatrices::Copy &data)
+{
+  // Reset local data
+  data.local_mass_matrix = 0.;
+  data.local_stiffness_matrix = 0.;
+
+  // Velocity's cell data
+  scratch.fe_values.reinit(cell);
+
+  const FEValuesExtractors::Vector  vector_extractor(0);
+
+  // Local to global indices mapping
+  cell->get_dof_indices(data.local_dof_indices);
+
+  // Loop over quadrature points
+  for (unsigned int q = 0; q < scratch.n_q_points; ++q)
+  {
+    // Extract test function values at the quadrature points
+    for (unsigned int i = 0; i < scratch.dofs_per_cell; ++i)
+    {
+      scratch.phi[i]      = scratch.fe_values[vector_extractor].value(i, q);
+      scratch.grad_phi[i] = scratch.fe_values[vector_extractor].gradient(i, q);
+    }
+
+    // Loop over local degrees of freedom
+    for (unsigned int i = 0; i < scratch.dofs_per_cell; ++i)
+      // Compute values of the lower triangular part (Symmetry)
+      for (unsigned int j = 0; j <= i; ++j)
+      {
+        // Local matrices
+        data.local_mass_matrix(i, j) += scratch.phi[i] *
+                                        scratch.phi[j] *
+                                        scratch.fe_values.JxW(q);
+        data.local_stiffness_matrix(i, j) +=  scalar_product(
+                                                scratch.grad_phi[i],
+                                                scratch.grad_phi[j]) *
+                                              scratch.fe_values.JxW(q);
+      } // Loop over local degrees of freedom
+  } // Loop over quadrature points
+
+  // Copy lower triangular part values into the upper triangular part
+  for (unsigned int i = 0; i < scratch.dofs_per_cell; ++i)
+    for (unsigned int j = i + 1; j < scratch.dofs_per_cell; ++j)
+    {
+      data.local_mass_matrix(i, j)      = data.local_mass_matrix(j, i);
+      data.local_stiffness_matrix(i, j) = data.local_stiffness_matrix(j, i);
+    }
+}
+
+
+
+template <int dim>
+void ProjectionSolverBase<dim>::copy_local_to_global_matrices_vector_field(
+ const AssemblyData::ProjectionSolverBase::VectorFieldConstantMatrices::Copy &data)
+{
+  vector_field->get_constraints().distribute_local_to_global(
+                                      data.local_mass_matrix,
+                                      data.local_dof_indices,
+                                      diffusion_step_mass_matrix);
+  vector_field->get_constraints().distribute_local_to_global(
+                                      data.local_stiffness_matrix,
+                                      data.local_dof_indices,
+                                      diffusion_step_stiffness_matrix);
+}
+
+template <int dim>
+void ProjectionSolverBase<dim>::assemble_constant_matrices_scalar_fields()
+{
+  // Reset data
+  zeroth_step_system_matrix     = 0.;
+  projection_step_system_matrix = 0.;
+
+  // Initiate the quadrature formula for exact numerical integration
+  const QGauss<dim>   quadrature_formula(lagrange_multiplier->fe_degree() + 1);
+
+  // Set up the lambda function for the local assembly operation
+  auto worker =
+    [this](const typename DoFHandler<dim>::active_cell_iterator &cell,
+           AssemblyData::ProjectionSolverBase::ScalarFieldsConstantMatrices::Scratch<dim> &scratch,
+           AssemblyData::ProjectionSolverBase::ScalarFieldsConstantMatrices::Copy &data)
+    {
+      this->assemble_local_matrices_scalar_fields(cell,
+                                                  scratch,
+                                                  data);
+    };
+
+  // Set up the lamba function for the copy local to global operation
+  auto copier =
+    [this](const AssemblyData::ProjectionSolverBase::ScalarFieldsConstantMatrices::Copy &data)
+    {
+      this->copy_local_to_global_matrices_scalar_fields(data);
+    };
+
+  // Assemble using the WorkStream approach
+  using CellFilter =
+    FilteredIterator<typename DoFHandler<dim>::active_cell_iterator>;
+
+  WorkStream::run
+  (CellFilter(IteratorFilters::LocallyOwnedCell(),
+              lagrange_multiplier->get_dof_handler().begin_active()),
+   CellFilter(IteratorFilters::LocallyOwnedCell(),
+              lagrange_multiplier->get_dof_handler().end()),
+   worker,
+   copier,
+   AssemblyData::ProjectionSolverBase::ScalarFieldsConstantMatrices::Scratch<dim>(
+    *this->mapping,
+    quadrature_formula,
+    lagrange_multiplier->get_finite_element(),
+    update_values|update_gradients|update_JxW_values),
+   AssemblyData::ProjectionSolverBase::ScalarFieldsConstantMatrices::Copy(
+    lagrange_multiplier->get_finite_element().dofs_per_cell));
+
+  // Compress global data
+  zeroth_step_system_matrix.compress(VectorOperation::add);
+  projection_step_system_matrix.compress(VectorOperation::add);
+}
+
+
+
+template <int dim>
+void ProjectionSolverBase<dim>::assemble_local_matrices_scalar_fields(
+ const typename DoFHandler<dim>::active_cell_iterator  &cell,
+ AssemblyData::ProjectionSolverBase::ScalarFieldsConstantMatrices::Scratch<dim> &scratch,
+ AssemblyData::ProjectionSolverBase::ScalarFieldsConstantMatrices::Copy &data)
+{
+  // Reset local data
+  data.local_mass_matrix      = 0.;
+  data.local_stiffness_matrix = 0.;
+
+  // Pressure's cell data
+  scratch.fe_values.reinit(cell);
+
+  // Local to global indices mapping
+  cell->get_dof_indices(data.local_dof_indices);
+
+  // Loop over quadrature points
+  for (unsigned int q = 0; q < scratch.n_q_points; ++q)
+  {
+    // Extract test function values at the quadrature points
+    for (unsigned int i = 0; i < scratch.dofs_per_cell; ++i)
+    {
+      scratch.phi[i]      = scratch.fe_values.shape_value(i, q);
+      scratch.grad_phi[i] = scratch.fe_values.shape_grad(i, q);
+    }
+
+    // Loop over local degrees of freedom
+    for (unsigned int i = 0; i < scratch.dofs_per_cell; ++i)
+      // Compute values of the lower triangular part (Symmetry)
+      for (unsigned int j = 0; j <= i; ++j)
+      {
+        // Local matrices
+        data.local_mass_matrix(i, j) += scratch.phi[i] *
+                                        scratch.phi[j] *
+                                        scratch.fe_values.JxW(q);
+        data.local_stiffness_matrix(i, j) +=  scratch.grad_phi[i] *
+                                              scratch.grad_phi[j] *
+                                              scratch.fe_values.JxW(q);
+      } // Loop over local degrees of freedom
+  } // Loop over quadrature points
+
+  // Copy lower triangular part values into the upper triangular part
+  for (unsigned int i = 0; i < scratch.dofs_per_cell; ++i)
+    for (unsigned int j = i + 1; j < scratch.dofs_per_cell; ++j)
+    {
+      data.local_mass_matrix(i, j)      = data.local_mass_matrix(j, i);
+      data.local_stiffness_matrix(i, j) = data.local_stiffness_matrix(j, i);
+    }
+}
+
+
+
+template <int dim>
+void ProjectionSolverBase<dim>::copy_local_to_global_matrices_scalar_fields(
+ const AssemblyData::ProjectionSolverBase::ScalarFieldsConstantMatrices::Copy &data)
+{
+  lagrange_multiplier->get_constraints().distribute_local_to_global(
+                                      data.local_stiffness_matrix,
+                                      data.local_dof_indices,
+                                      zeroth_step_system_matrix);
+  auxiliary_scalar->get_constraints().distribute_local_to_global(
+                                      data.local_stiffness_matrix,
+                                      data.local_dof_indices,
+                                      projection_step_system_matrix);
+}
 
 
 

--- a/source/solver_class.cc
+++ b/source/solver_class.cc
@@ -66,7 +66,8 @@ SolverBase<dim>(time_stepping,
                 external_timer),
 norm_diffusion_step_rhs(std::numeric_limits<double>::lowest()),
 norm_projection_step_rhs(std::numeric_limits<double>::lowest()),
-flag_setup_auxiliary_scalar(true)
+flag_setup_auxiliary_scalar(true),
+flag_mean_value_constrain(false)
 {
   // Explicitly set the supply term's pointer to null
   ptr_supply_term = nullptr;
@@ -75,10 +76,115 @@ flag_setup_auxiliary_scalar(true)
 
 
 template <int dim>
+void ProjectionSolverBase<dim>::setup()
+{
+  if (flag_setup_auxiliary_scalar)
+    setup_auxiliary_scalar();
+
+  this->setup_matrices();
+
+  this->setup_vectors();
+
+  assemble_constant_matrices();
+
+  if (auxiliary_scalar->get_dirichlet_boundary_conditions().empty())
+    flag_mean_value_constrain = true;
+
+  this->flag_matrices_were_updated = true;
+
+  if (this->time_stepping.get_step_number() == 0)
+    zeroth_step();
+}
+
+
+
+template <int dim>
+void ProjectionSolverBase<dim>::clear()
+{
+  // Pointers
+  ptr_supply_term = nullptr;
+
+  // Auxiliary scalar
+  auxiliary_scalar->clear();
+
+  // Preconditioners
+  diffusion_step_preconditioner.reset();
+  projection_step_preconditioner.reset();
+  zeroth_step_preconditioner.reset();
+
+  // Matrices
+  diffusion_step_system_matrix.clear();
+  diffusion_step_mass_matrix.clear();
+  diffusion_step_stiffness_matrix.clear();
+  diffusion_step_mass_plus_stiffness_matrix.clear();
+  diffusion_step_advection_matrix.clear();
+  projection_step_system_matrix.clear();
+  zeroth_step_system_matrix.clear();
+
+  // Vectors
+  diffusion_step_rhs.clear();
+  projection_step_rhs.clear();
+  zeroth_step_rhs.clear();
+
+  // Norms
+  norm_projection_step_rhs  = std::numeric_limits<double>::lowest();
+  norm_diffusion_step_rhs   = std::numeric_limits<double>::lowest();
+
+  // Flags
+  flag_setup_auxiliary_scalar       = true;
+  flag_mean_value_constrain         = false;
+  this->flag_matrices_were_updated  = true;
+}
+
+
+template <int dim>
 void ProjectionSolverBase<dim>::set_supply_term(
   TensorFunction<1, dim> &supply_term)
 {
   ptr_supply_term = &supply_term;
+}
+
+
+
+template <int dim>
+void ProjectionSolverBase<dim>::zeroth_step()
+{
+  if (ptr_supply_term != nullptr)
+    ptr_supply_term->set_time(this->time_stepping.get_start_time());
+
+  assemble_zeroth_step();
+
+  solve_zeroth_step();
+}
+
+
+
+template <int dim>
+void ProjectionSolverBase<dim>::diffusion_step(const bool reinit_preconditioner)
+{
+  assemble_diffusion_step();
+
+  solve_diffusion_step(reinit_preconditioner);
+}
+
+
+
+template <int dim>
+void ProjectionSolverBase<dim>::projection_step(const bool reinit_preconditioner)
+{
+  assemble_projection_step();
+
+  solve_projection_step(reinit_preconditioner);
+}
+
+
+
+template <int dim>
+void ProjectionSolverBase<dim>::assemble_constant_matrices()
+{
+  assemble_constant_matrices_vector_field();
+
+  assemble_constant_matrices_scalar_fields();
 }
 
 

--- a/source/solver_class.cc
+++ b/source/solver_class.cc
@@ -1,5 +1,14 @@
 #include <rotatingMHD/solver_class.h>
+#include <rotatingMHD/utility.h>
 
+#include <deal.II/dofs/dof_tools.h>
+#ifdef USE_PETSC_LA
+  #include <deal.II/lac/dynamic_sparsity_pattern.h>
+  #include <deal.II/lac/sparsity_tools.h>
+#else
+  #include <deal.II/lac/trilinos_sparsity_pattern.h>
+#endif
+#include <deal.II/numerics/vector_tools.h>
 
 
 namespace RMHD
@@ -54,16 +63,57 @@ flag_matrices_were_updated(true)
 
 
 template<int dim>
+void SolverBase<dim>::clear()
+{
+  flag_matrices_were_updated = true;
+}
+
+
+
+
+template<int dim>
 ProjectionSolverBase<dim>::ProjectionSolverBase(
-  TimeDiscretization::VSIMEXMethod                &time_stepping,
-  const std::shared_ptr<Mapping<dim>>             external_mapping,
-  const std::shared_ptr<ConditionalOStream>       external_pcout,
-  const std::shared_ptr<TimerOutput>              external_timer)
+  const RunTimeParameters::ProjectionSolverParametersBase &parameters,
+  TimeDiscretization::VSIMEXMethod                        &time_stepping,
+  std::shared_ptr<Entities::FE_VectorField<dim>>          &vector_field,
+  std::shared_ptr<Entities::FE_ScalarField<dim>>          &lagrange_multiplier,
+  const std::shared_ptr<Mapping<dim>>                     external_mapping,
+  const std::shared_ptr<ConditionalOStream>               external_pcout,
+  const std::shared_ptr<TimerOutput>                      external_timer)
 :
 SolverBase<dim>(time_stepping,
                 external_mapping,
                 external_pcout,
                 external_timer),
+projection_solver_parameters(parameters),
+vector_field(vector_field),
+lagrange_multiplier(lagrange_multiplier),
+norm_diffusion_step_rhs(std::numeric_limits<double>::lowest()),
+norm_projection_step_rhs(std::numeric_limits<double>::lowest()),
+flag_setup_auxiliary_scalar(true),
+flag_mean_value_constrain(false)
+{
+  // Explicitly set the supply term's pointer to null
+  ptr_supply_term = nullptr;
+}
+
+
+
+template<int dim>
+ProjectionSolverBase<dim>::ProjectionSolverBase(
+  const RunTimeParameters::ProjectionSolverParametersBase &parameters,
+  TimeDiscretization::VSIMEXMethod                        &time_stepping,
+  std::shared_ptr<Entities::FE_VectorField<dim>>          &vector_field,
+  const std::shared_ptr<Mapping<dim>>                     external_mapping,
+  const std::shared_ptr<ConditionalOStream>               external_pcout,
+  const std::shared_ptr<TimerOutput>                      external_timer)
+:
+SolverBase<dim>(time_stepping,
+                external_mapping,
+                external_pcout,
+                external_timer),
+projection_solver_parameters(parameters),
+vector_field(vector_field),
 norm_diffusion_step_rhs(std::numeric_limits<double>::lowest()),
 norm_projection_step_rhs(std::numeric_limits<double>::lowest()),
 flag_setup_auxiliary_scalar(true),
@@ -76,24 +126,37 @@ flag_mean_value_constrain(false)
 
 
 template <int dim>
-void ProjectionSolverBase<dim>::setup()
+void ProjectionSolverBase<dim>::solve()
 {
-  if (flag_setup_auxiliary_scalar)
-    setup_auxiliary_scalar();
+  if (vector_field->solution.size() != diffusion_step_rhs.size())
+  {
+    setup();
 
-  this->setup_matrices();
+    diffusion_step(true);
 
-  this->setup_vectors();
+    projection_step(true);
 
-  assemble_constant_matrices();
+    correction_step(true);
 
-  if (auxiliary_scalar->get_dirichlet_boundary_conditions().empty())
-    flag_mean_value_constrain = true;
+    this->flag_matrices_were_updated = false;
+  }
+  else
+  {
+    diffusion_step(this->time_stepping.get_step_number() %
+                   projection_solver_parameters.preconditioner_update_frequency == 0 ||
+                   this->time_stepping.get_step_number() == 1);
 
-  this->flag_matrices_were_updated = true;
+    projection_step(false);
 
-  if (this->time_stepping.get_step_number() == 0)
-    zeroth_step();
+    correction_step(false);
+  }
+
+  auxiliary_scalar->update_solution_vectors();
+
+  previous_alpha_zeros[1] = previous_alpha_zeros[0];
+  previous_alpha_zeros[0] = this->time_stepping.get_alpha()[0];
+  previous_step_sizes[1]  = previous_step_sizes[0];
+  previous_step_sizes[0]  = this->time_stepping.get_next_step_size();
 }
 
 
@@ -133,7 +196,8 @@ void ProjectionSolverBase<dim>::clear()
   // Flags
   flag_setup_auxiliary_scalar       = true;
   flag_mean_value_constrain         = false;
-  this->flag_matrices_were_updated  = true;
+
+  SolverBase<dim>::clear();
 }
 
 
@@ -142,6 +206,224 @@ void ProjectionSolverBase<dim>::set_supply_term(
   TensorFunction<1, dim> &supply_term)
 {
   ptr_supply_term = &supply_term;
+}
+
+
+
+template <int dim>
+void ProjectionSolverBase<dim>::setup()
+{
+  if (flag_setup_auxiliary_scalar)
+    setup_auxiliary_scalar();
+
+  this->setup_matrices();
+
+  this->setup_vectors();
+
+  assemble_constant_matrices();
+
+  if (auxiliary_scalar->get_dirichlet_boundary_conditions().empty())
+    flag_mean_value_constrain = true;
+
+  this->flag_matrices_were_updated = true;
+
+  if (this->time_stepping.get_step_number() == 0)
+    zeroth_step();
+}
+
+
+
+template <int dim>
+void ProjectionSolverBase<dim>::setup_matrices()
+{
+  setup_matrices_vector_field();
+
+  setup_matrices_scalar_fields();
+}
+
+
+
+template <int dim>
+void ProjectionSolverBase<dim>::setup_matrices_vector_field()
+{
+  // Clear the matrices
+  diffusion_step_system_matrix.clear();
+  diffusion_step_mass_matrix.clear();
+  diffusion_step_stiffness_matrix.clear();
+  diffusion_step_mass_plus_stiffness_matrix.clear();
+  diffusion_step_advection_matrix.clear();
+
+  #ifdef USE_PETSC_LA
+    // Initiate the sparsity pattern
+    DynamicSparsityPattern
+    sparsity_pattern(vector_field->get_locally_relevant_dofs());
+
+    // Create the sparsity pattern
+    DoFTools::make_sparsity_pattern(vector_field->get_dof_handler(),
+                                    sparsity_pattern,
+                                    vector_field->get_constraints(),
+                                    false,
+                                    Utilities::MPI::this_mpi_process(this->mpi_communicator));
+
+    // Distribute the sparsity pattern
+    SparsityTools::distribute_sparsity_pattern
+    (sparsity_pattern,
+     vector_field->get_locally_owned_dofs(),
+     this->mpi_communicator,
+     vector_field->get_locally_relevant_dofs());
+
+    // Re-initate the matrices
+    diffusion_step_system_matrix.reinit
+    (vector_field->get_locally_owned_dofs(),
+     vector_field->get_locally_owned_dofs(),
+     sparsity_pattern,
+     this->mpi_communicator);
+    diffusion_step_mass_matrix.reinit
+    (vector_field->get_locally_owned_dofs(),
+     vector_field->get_locally_owned_dofs(),
+     sparsity_pattern,
+     this->mpi_communicator);
+    diffusion_step_stiffness_matrix.reinit
+    (vector_field->get_locally_owned_dofs(),
+     vector_field->get_locally_owned_dofs(),
+     sparsity_pattern,
+     this->mpi_communicator);
+    diffusion_step_mass_plus_stiffness_matrix.reinit
+    (vector_field->get_locally_owned_dofs(),
+     vector_field->get_locally_owned_dofs(),
+     sparsity_pattern,
+     this->mpi_communicator);
+    diffusion_step_advection_matrix.reinit
+    (vector_field->get_locally_owned_dofs(),
+     vector_field->get_locally_owned_dofs(),
+     sparsity_pattern,
+     this->mpi_communicator);
+
+  #else
+    // Initiate sparsity pattern
+    TrilinosWrappers::SparsityPattern
+    sparsity_pattern(vector_field->get_locally_owned_dofs(),
+                     vector_field->get_locally_owned_dofs(),
+                     vector_field->get_locally_relevant_dofs(),
+                     this->mpi_communicator);
+
+    // Make sparsity pattern
+    DoFTools::make_sparsity_pattern(vector_field->get_dof_handler(),
+                                    sparsity_pattern,
+                                    vector_field->get_constraints(),
+                                    false,
+                                    Utilities::MPI::this_mpi_process(this->mpi_communicator));
+
+    // Compress sparsity pattern
+    sparsity_pattern.compress();
+
+    // Re-initiate matrices
+    diffusion_step_system_matrix.reinit(sparsity_pattern);
+    diffusion_step_mass_matrix.reinit(sparsity_pattern);
+    diffusion_step_stiffness_matrix.reinit(sparsity_pattern);
+    diffusion_step_mass_plus_stiffness_matrix.reinit(sparsity_pattern);
+    diffusion_step_advection_matrix.reinit(sparsity_pattern);
+  #endif
+}
+
+
+
+template <int dim>
+void ProjectionSolverBase<dim>::setup_matrices_scalar_fields()
+{
+  // Clear matrices
+  projection_step_system_matrix.clear();
+  zeroth_step_system_matrix.clear();
+
+  #ifdef USE_PETSC_LA
+    // Initiate the sparsity patterns
+    DynamicSparsityPattern
+    lagrange_multiplier_sparsity_pattern(lagrange_multiplier->get_locally_relevant_dofs());
+    DynamicSparsityPattern
+    auxiliary_scalar_sparsity_pattern(auxiliary_scalar->get_locally_relevant_dofs());
+
+    // Make the sparsity patterns
+    DoFTools::make_sparsity_pattern(lagrange_multiplier->get_dof_handler(),
+                                    lagrange_multiplier_sparsity_pattern,
+                                    lagrange_multiplier->get_constraints(),
+                                    false,
+                                    Utilities::MPI::this_mpi_process(mpi_communicator));
+    DoFTools::make_sparsity_pattern(auxiliary_scalar->get_dof_handler(),
+                                    auxiliary_scalar_sparsity_pattern,
+                                    auxiliary_scalar->get_constraints(),
+                                    false,
+                                    Utilities::MPI::this_mpi_process(mpi_communicator));
+
+    // Distribute the sparsity patterns
+    SparsityTools::distribute_sparsity_pattern
+    (lagrange_multiplier_sparsity_pattern,
+     lagrange_multiplier->get_locally_owned_dofs(),
+     this->mpi_communicator,
+     lagrange_multiplier->get_locally_relevant_dofs());
+    SparsityTools::distribute_sparsity_pattern
+    (auxiliary_scalar_sparsity_pattern,
+     auxiliary_scalar->get_locally_owned_dofs(),
+     this->mpi_communicator,
+     auxiliary_scalar->locally_relevant_dofs);
+
+    // Re-initiate the matrices
+    zeroth_step_system_matrix.reinit
+    (lagrange_multiplier->get_locally_owned_dofs(),
+     lagrange_multiplier->get_locally_owned_dofs(),
+     lagrange_multiplier_sparsity_pattern,
+     this->mpi_communicator);
+    projection_step_system_matrix.reinit
+    (auxiliary_scalar->get_locally_owned_dofs(),
+     auxiliary_scalar->get_locally_owned_dofs(),
+     auxiliary_scalar_sparsity_pattern,
+     this->mpi_communicator);
+
+  #else
+    TrilinosWrappers::SparsityPattern
+    lagrange_multiplier_sparsity_pattern(
+      lagrange_multiplier->get_locally_owned_dofs(),
+      lagrange_multiplier->get_locally_owned_dofs(),
+      lagrange_multiplier->get_locally_relevant_dofs(),
+      this->mpi_communicator);
+
+    TrilinosWrappers::SparsityPattern
+    auxiliary_scalar_sparsity_pattern(
+      auxiliary_scalar->get_locally_owned_dofs(),
+      auxiliary_scalar->get_locally_owned_dofs(),
+      auxiliary_scalar->get_locally_relevant_dofs(),
+      this->mpi_communicator);
+
+    DoFTools::make_sparsity_pattern(
+      lagrange_multiplier->get_dof_handler(),
+      lagrange_multiplier_sparsity_pattern,
+      lagrange_multiplier->get_constraints(),
+      false,
+      Utilities::MPI::this_mpi_process(this->mpi_communicator));
+
+    DoFTools::make_sparsity_pattern(
+      auxiliary_scalar->get_dof_handler(),
+      auxiliary_scalar_sparsity_pattern,
+      auxiliary_scalar->get_constraints(),
+      false,
+      Utilities::MPI::this_mpi_process(this->mpi_communicator));
+
+    lagrange_multiplier_sparsity_pattern.compress();
+    auxiliary_scalar_sparsity_pattern.compress();
+
+    zeroth_step_system_matrix.reinit(lagrange_multiplier_sparsity_pattern);
+    projection_step_system_matrix.reinit(auxiliary_scalar_sparsity_pattern);
+
+  #endif
+}
+
+
+
+template <int dim>
+void ProjectionSolverBase<dim>::setup_vectors()
+{
+  diffusion_step_rhs.reinit(vector_field->distributed_vector);
+  projection_step_rhs.reinit(auxiliary_scalar->distributed_vector);
+  zeroth_step_rhs.reinit(lagrange_multiplier->distributed_vector);
 }
 
 
@@ -160,11 +442,173 @@ void ProjectionSolverBase<dim>::zeroth_step()
 
 
 template <int dim>
+std::pair<int, double> ProjectionSolverBase<dim>::solve_zeroth_step()
+{
+  LinearAlgebra::MPI::Vector distributed_lagrange_multiplier(lagrange_multiplier->distributed_vector);
+  distributed_lagrange_multiplier = lagrange_multiplier->old_solution;
+
+  const typename RunTimeParameters::LinearSolverParameters &solver_parameters
+    = projection_solver_parameters.zeroth_step_solver_parameters;
+
+  build_preconditioner(zeroth_step_preconditioner,
+                       zeroth_step_system_matrix,
+                       solver_parameters.preconditioner_parameters_ptr,
+                       (lagrange_multiplier->fe_degree() > 1? true: false));
+
+  AssertThrow(zeroth_step_preconditioner != nullptr,
+              ExcMessage("The pointer to the Poisson pre-step's preconditioner has not being initialized."));
+
+  SolverControl solver_control(
+    solver_parameters.n_maximum_iterations,
+    std::max(solver_parameters.relative_tolerance * zeroth_step_rhs.l2_norm(),
+             solver_parameters.absolute_tolerance));
+
+  #ifdef USE_PETSC_LA
+    LinearAlgebra::SolverCG solver(solver_control,
+                                   this->mpi_communicator);
+  #else
+    LinearAlgebra::SolverCG solver(solver_control);
+  #endif
+
+  try
+  {
+    solver.solve(zeroth_step_system_matrix,
+                 distributed_lagrange_multiplier,
+                 zeroth_step_rhs,
+                 *zeroth_step_preconditioner);
+  }
+  catch (std::exception &exc)
+  {
+    std::cerr << std::endl << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+    std::cerr << "Exception in the solve method of the poisson pre-step: " << std::endl
+              << exc.what() << std::endl
+              << "Aborting!" << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+    std::abort();
+  }
+  catch (...)
+  {
+    std::cerr << std::endl << std::endl
+              << "----------------------------------------------------"
+                << std::endl;
+    std::cerr << "Unknown exception in the solve method of the poisson pre-step!" << std::endl
+              << "Aborting!" << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+    std::abort();
+  }
+
+  lagrange_multiplier->get_constraints().distribute(distributed_lagrange_multiplier);
+
+  lagrange_multiplier->old_solution = distributed_lagrange_multiplier;
+
+  if (flag_mean_value_constrain)
+  {
+    const LinearAlgebra::MPI::Vector::value_type mean_value
+      = VectorTools::compute_mean_value(lagrange_multiplier->get_dof_handler(),
+                                        QGauss<dim>(lagrange_multiplier->fe_degree() + 1),
+                                        lagrange_multiplier->old_solution,
+                                        0);
+
+    distributed_lagrange_multiplier.add(-mean_value);
+    lagrange_multiplier->old_solution = distributed_lagrange_multiplier;
+  }
+
+  return {solver_control.last_step(), solver_control.last_value()};
+}
+
+
+template <int dim>
 void ProjectionSolverBase<dim>::diffusion_step(const bool reinit_preconditioner)
 {
   assemble_diffusion_step();
 
   solve_diffusion_step(reinit_preconditioner);
+}
+
+
+
+template <int dim>
+std::pair<int, double> ProjectionSolverBase<dim>::solve_diffusion_step(const bool reinit_preconditioner)
+{
+  LinearAlgebra::MPI::Vector distributed_vector_field(vector_field->distributed_vector);
+  distributed_vector_field = vector_field->solution;
+
+  /* The following pointer holds the address to the correct matrix
+  depending on if the semi-implicit scheme is chosen or not */
+  const LinearAlgebra::MPI::SparseMatrix  * system_matrix;
+
+  if (projection_solver_parameters.convective_term_time_discretization ==
+      RunTimeParameters::ConvectiveTermTimeDiscretization::semi_implicit)
+    system_matrix = &diffusion_step_system_matrix;
+  else
+    system_matrix = &diffusion_step_mass_plus_stiffness_matrix;
+
+
+  const typename RunTimeParameters::LinearSolverParameters &solver_parameters
+    = projection_solver_parameters.diffusion_step_solver_parameters;
+  if (reinit_preconditioner)
+  {
+    build_preconditioner(diffusion_step_preconditioner,
+                         *system_matrix,
+                         solver_parameters.preconditioner_parameters_ptr,
+                         (vector_field->fe_degree() > 1? true: false));
+  }
+
+  AssertThrow(diffusion_step_preconditioner != nullptr,
+              ExcMessage("The pointer to the diffusion step's preconditioner has not being initialized."));
+
+  SolverControl solver_control(
+    projection_solver_parameters.diffusion_step_solver_parameters.n_maximum_iterations,
+    std::max(solver_parameters.relative_tolerance * diffusion_step_rhs.l2_norm(),
+             solver_parameters.absolute_tolerance));
+
+  #ifdef USE_PETSC_LA
+    LinearAlgebra::SolverGMRES solver(solver_control,
+                                      this->mpi_communicator);
+  #else
+    LinearAlgebra::SolverGMRES solver(solver_control);
+  #endif
+
+  try
+  {
+    solver.solve(*system_matrix,
+                 distributed_vector_field,
+                 diffusion_step_rhs,
+                 *diffusion_step_preconditioner);
+  }
+  catch (std::exception &exc)
+  {
+    std::cerr << std::endl << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+    std::cerr << "Exception in the solve method of the diffusion step: " << std::endl
+              << exc.what() << std::endl
+              << "Aborting!" << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+    std::abort();
+  }
+  catch (...)
+  {
+    std::cerr << std::endl << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+    std::cerr << "Unknown exception in the solve method of the diffusion step!" << std::endl
+              << "Aborting!" << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+    std::abort();
+  }
+
+  vector_field->get_constraints().distribute(distributed_vector_field);
+
+  vector_field->solution = distributed_vector_field;
+
+  return {solver_control.last_step(), solver_control.last_value()};
 }
 
 
@@ -180,12 +624,97 @@ void ProjectionSolverBase<dim>::projection_step(const bool reinit_preconditioner
 
 
 template <int dim>
+std::pair<int, double>  ProjectionSolverBase<dim>::solve_projection_step(const bool reinit_preconditioner)
+{
+  LinearAlgebra::MPI::Vector distributed_auxiliary_scalar(auxiliary_scalar->distributed_vector);
+  distributed_auxiliary_scalar = auxiliary_scalar->solution;
+
+  const typename RunTimeParameters::LinearSolverParameters &solver_parameters
+    = projection_solver_parameters.projection_step_solver_parameters;
+  if (reinit_preconditioner)
+  {
+    build_preconditioner(projection_step_preconditioner,
+                         projection_step_system_matrix,
+                         solver_parameters.preconditioner_parameters_ptr,
+                         (auxiliary_scalar->fe_degree() > 1? true: false));
+  }
+
+  AssertThrow(projection_step_preconditioner != nullptr,
+              ExcMessage("The pointer to the projection step's preconditioner has not being initialized."));
+
+  SolverControl solver_control(
+    solver_parameters.n_maximum_iterations,
+    std::max(solver_parameters.relative_tolerance * projection_step_rhs.l2_norm(),
+             solver_parameters.absolute_tolerance));
+
+  #ifdef USE_PETSC_LA
+    LinearAlgebra::SolverCG solver(solver_control,
+                                   this->mpi_communicator);
+  #else
+    LinearAlgebra::SolverCG solver(solver_control);
+  #endif
+
+  try
+  {
+    solver.solve(projection_step_system_matrix,
+                 distributed_auxiliary_scalar,
+                 projection_step_rhs,
+                 *projection_step_preconditioner);
+  }
+  catch (std::exception &exc)
+  {
+    std::cerr << std::endl << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+    std::cerr << "Exception in the solve method of the projection step: " << std::endl
+              << exc.what() << std::endl
+              << "Aborting!" << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+    std::abort();
+  }
+  catch (...)
+  {
+    std::cerr << std::endl << std::endl
+              << "----------------------------------------------------"
+                << std::endl;
+    std::cerr << "Unknown exception in the solve method of the projection step!" << std::endl
+              << "Aborting!" << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+    std::abort();
+  }
+
+  auxiliary_scalar->get_constraints().distribute(distributed_auxiliary_scalar);
+
+  auxiliary_scalar->solution = distributed_auxiliary_scalar;
+
+  if (flag_mean_value_constrain)
+  {
+    const LinearAlgebra::MPI::Vector::value_type mean_value
+      = VectorTools::compute_mean_value(auxiliary_scalar->get_dof_handler(),
+                                        QGauss<dim>(auxiliary_scalar->fe_degree() + 1),
+                                        auxiliary_scalar->solution,
+                                        0);
+
+    distributed_auxiliary_scalar.add(-mean_value);
+    auxiliary_scalar->solution = distributed_auxiliary_scalar;
+  }
+
+  return {solver_control.last_step(), solver_control.last_value()};
+}
+
+
+
+template <int dim>
 void ProjectionSolverBase<dim>::assemble_constant_matrices()
 {
   assemble_constant_matrices_vector_field();
 
   assemble_constant_matrices_scalar_fields();
 }
+
+
 
 
 
@@ -197,8 +726,8 @@ void ProjectionSolverBase<dim>::assemble_constant_matrices()
 
 
 
-template struct RMHD::Solvers::SolverBase<2>;
-template struct RMHD::Solvers::SolverBase<3>;
+template class RMHD::Solvers::SolverBase<2>;
+template class RMHD::Solvers::SolverBase<3>;
 
-template struct RMHD::Solvers::ProjectionSolverBase<2>;
-template struct RMHD::Solvers::ProjectionSolverBase<3>;
+template class RMHD::Solvers::ProjectionSolverBase<2>;
+template class RMHD::Solvers::ProjectionSolverBase<3>;


### PR DESCRIPTION
This pull-request equips the `ProjectionSolverBase<dim>` class with methods which would be completely or mostly the same for the hydrodynamic and the magnetic induction problems. The generality is gained by introducing the `FE_VectorField` and `FE_ScalarField` `vector_field` and `lagrange_multiplier`, respectively, as `shared_ptr` and a  `ProjectionSolverParametersBase` `struct`. These allow to move many of the methods to the base class at the cost of having duplicates (This will be easier to explain when I finish the draft of `MagneticInduction`)

The class may be subject to changes as I work on `MagneticInduction` but the basic idea and methods can be reviewed.